### PR TITLE
change upstream debian repository location on stretch

### DIFF
--- a/configs-stretch/etc/apt/sources.list.d/debian-upstream.list
+++ b/configs-stretch/etc/apt/sources.list.d/debian-upstream.list
@@ -1,0 +1,3 @@
+deb http://deb.debian.org/debian/ stretch main
+deb http://deb.debian.org/debian/ stretch-updates main
+deb http://security.debian.org stretch/updates main

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (1.82.1) stable; urgency=medium
+
+  * change upstream debian repository location on stretch
+
+ -- Pavel Poglazov <poglazov@contactless.ru>  Mon, 01 Jun 2020 00:30:01 +0300
+
 wb-configs (1.82.0) stable; urgency=medium
 
   * move /dev/ttyMOD*, /dev/ttyGSM and /dev/ttyRS485* to dialout group

--- a/debian/wb-configs-stretch.postinst
+++ b/debian/wb-configs-stretch.postinst
@@ -71,4 +71,9 @@ if [ "$1" = "configure" ]; then
     wb_check_undisplace_unlink_from /etc/ssh/sshd_config "" wb-configs "1.75.4"
 fi
 
+# stretch repos have been moved to separate file
+sed -i '\+deb http://mirror.yandex.ru/debian/ stretch main+d' /etc/apt/sources.list
+sed -i '\+deb http://mirror.yandex.ru/debian/ stretch-updates main+d' /etc/apt/sources.list
+sed -i '\+deb http://security.debian.org stretch/updates main+d' /etc/apt/sources.list
+
 #DEBHELPER#


### PR DESCRIPTION
```
root@wirenboard-AQZBLNTY:~# cat /etc/apt/sources.list
deb http://mirror.yandex.ru/debian/ stretch main
deb http://mirror.yandex.ru/debian/ stretch-updates main
deb http://security.debian.org stretch/updates main
root@wirenboard-AQZBLNTY:~# apt update
Ign:1 http://mirror.yandex.ru/debian stretch InRelease
Hit:2 http://security.debian.org stretch/updates InRelease      
Hit:3 http://releases.contactless.ru/stable/stretch stretch InRelease          
Hit:4 http://mirror.yandex.ru/debian stretch-updates InRelease                 
Hit:5 http://mirror.yandex.ru/debian stretch Release                           
Hit:6 http://cdn-fastly.deb.debian.org/debian stretch-backports InRelease
Reading package lists... Done
Building dependency tree       
Reading state information... Done
1 package can be upgraded. Run 'apt list --upgradable' to see it.
root@wirenboard-AQZBLNTY:~# dpkg -i wb-configs-stretch_1.82.1_all-stretch.deb 
(Reading database ... 27721 files and directories currently installed.)
Preparing to unpack wb-configs-stretch_1.82.1_all-stretch.deb ...
Unpacking wb-configs-stretch (1.82.1) over (1.82.0) ...
Setting up wb-configs-stretch (1.82.1) ...
root@wirenboard-AQZBLNTY:~# cat /etc/apt/sources.list
root@wirenboard-AQZBLNTY:~# cat /etc/apt/sources.list
root@wirenboard-AQZBLNTY:~# apt update
Ign:1 http://deb.debian.org/debian stretch InRelease
Hit:2 http://security.debian.org stretch/updates InRelease                     
Get:3 http://deb.debian.org/debian stretch-updates InRelease [91,0 kB]         
Get:4 http://deb.debian.org/debian stretch Release [118 kB]                    
Hit:6 http://releases.contactless.ru/stable/stretch stretch InRelease          
Get:7 http://deb.debian.org/debian stretch Release.gpg [2 410 B]         
Hit:5 http://cdn-fastly.deb.debian.org/debian stretch-backports InRelease
Get:8 http://deb.debian.org/debian stretch-updates/main armhf Packages [27,9 kB]
Get:9 http://deb.debian.org/debian stretch-updates/main Translation-en [11,9 kB]
Get:10 http://deb.debian.org/debian stretch/main armhf Packages [6 912 kB]
Get:11 http://deb.debian.org/debian stretch/main Translation-en [5 381 kB]     
Fetched 12,5 MB in 32s (384 kB/s)                                              
Reading package lists... Done
Building dependency tree       
Reading state information... Done
1 package can be upgraded. Run 'apt list --upgradable' to see it.
root@wirenboard-AQZBLNTY:~# 
```