### PR TITLE
rsyslog does not replace busybox-syslogd automaticaly

### DIFF
--- a/configs-stretch/etc/logrotate.d/messages
+++ b/configs-stretch/etc/logrotate.d/messages
@@ -1,0 +1,6 @@
+ /var/log/messages {
+  compress
+  rotate 2
+  missingok
+  size 200k 
+}

--- a/configs-stretch/etc/watchdog.conf.wb
+++ b/configs-stretch/etc/watchdog.conf.wb
@@ -17,8 +17,6 @@ min-memory		= 256
 
 # Test if vital daemons are running
 pidfile		= /var/run/sshd.pid
-pidfile		= /var/run/mosquitto.pid
-pidfile		= /var/run/nginx.pid
 
 # Timeout for all tests
 retry-timeout		= 30

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (1.84.2) stable; urgency=medium
+
+  * Support for both rsyslog and busybox-syslogd. One can install rsyslog manually
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 09 Mar 2021 10:47:00 +0500
+
 wb-configs (1.84.1) stable; urgency=medium
 
   * Grant write permissions to /var/log/mosquitto to mosquitto user

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 wb-configs (1.84.2) stable; urgency=medium
 
+  * do not reboot system if mosquitto or nginx are stopped
   * Support for both rsyslog and busybox-syslogd. One can install rsyslog manually
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 09 Mar 2021 10:47:00 +0500

--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Description: Default wheezy-specific config files for Wiren Board
 
 Package: wb-configs-stretch
 Architecture: all
-Depends: systemd (>= 232-25), apt-transport-https, rsyslog
+Depends: systemd (>= 232-25), apt-transport-https, rsyslog | busybox-syslogd
 Provides: ${diverted-files}
 Conflicts: ${diverted-files}, wb-homa-adc (<< 1.9.2), wb-homa-gpio (<< 1.14), wb-mqtt-serial(<< 1.14.2), wr-rules(<< 1.5.1)
 Replaces: wb-configs-wheezy, wb-configs (<< 1.84.0)

--- a/debian/wb-configs-stretch.postinst
+++ b/debian/wb-configs-stretch.postinst
@@ -82,6 +82,7 @@ sed -i '\+deb http://security.debian.org stretch/updates main+d' $sources_file
 
 #DEBHELPER#
 
-deb-systemd-invoke restart rsyslog
+deb-systemd-invoke restart busybox-syslogd || true
+deb-systemd-invoke restart rsyslog || true
 deb-systemd-invoke start watchdog
 deb-systemd-invoke restart systemd-journald

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -46,5 +46,8 @@ fi
 
 udevadm trigger # apply new udev rules
 
-rm -f /etc/logrotate.d/messages
+if dpkg-query -s rsyslog; then
+    rm -f /etc/logrotate.d/messages
+fi
+
 rm -f /etc/logrotate.d/rsyslog


### PR DESCRIPTION
apt dist-upgrade can fail because of watchdog. apt removes busybox-syslogd but watchdog is not notifyed about it, so it can reset device. We support both busybox-syslogd and rsyslog in configs, so one can install rsyslog manually after dist-upgrade.