### PR TITLE
renamed "Wirenboard" to "Wiren Board" in banner

### DIFF
--- a/configs/etc/update-motd.d/10-wirenboard
+++ b/configs/etc/update-motd.d/10-wirenboard
@@ -8,7 +8,7 @@ echo -ne "\u001b[32m"
 figlet wirenboard
 echo -ne "\u001b[0m"
 
-echo -e "Welcome to \u001b[32mWirenboard ${WB_BOARD_REVISION}\u001b[0m \
+echo -e "Welcome to \u001b[32mWiren Board ${WB_BOARD_REVISION}\u001b[0m \
 (s/n \u001b[1m${SHORT_SN}\u001b[0m), \
 release \u001b[1m\u001b[37m${RELEASE_NAME}\u001b[0m \
 (as \u001b[1m\u001b[37m${SUITE}\u001b[0m)"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (2.0.1) stable; urgency=medium
+
+  * renamed "Wirenboard" to "Wiren Board" in banner
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Fri, 30 Apr 2021 18:13:45 +0300
+
 wb-configs (2.0) stable; urgency=medium
 
   * remove wheezy support


### PR DESCRIPTION
Gently-asked-by: Pavel Poglazov <poglazoff@gmail.com>