### PR TITLE
add wb-suite to recommends

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (2.1.0) stable; urgency=medium
+
+  * add wb-suite to recommends to install it automatically on update
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 03 Aug 2021 15:04:03 +0300
+
 wb-configs (2.0.1) stable; urgency=medium
 
   * renamed "Wirenboard" to "Wiren Board" in banner

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1), inotify-too
 Pre-Depends: wb-update-manager
 Provides: ${diverted-files}, mqtt-wss
 Conflicts: ${diverted-files}, mqtt-wss
-Recommends: wb-essential, figlet
+Recommends: wb-essential, wb-suite, figlet
 Replaces: mqtt-wss
 Description: Default common config files for Wiren Board
 


### PR DESCRIPTION
This can deal with wb-mqtt-gpio or some other packages removals while moving to the new repo (https://wirenboard.bitrix24.ru/company/personal/user/28/tasks/task/view/38030/)