### PR TITLE
Disable client side caching of index.html

### DIFF
--- a/configs/etc/nginx/sites-available/default.wb
+++ b/configs/etc/nginx/sites-available/default.wb
@@ -24,13 +24,19 @@ server {
 	#listen   [::]:80 default_server ipv6only=on; ## listen for ipv6
 
 	root /var/www;
-	index index.html;
 
 	# Make site accessible from http://localhost/
 	server_name localhost;
-	try_files $uri $uri/ /index.html;
 
-	expires max;
+	location / {
+		index index.html;
+		try_files $uri $uri/ /index.html;
+		add_header Cache-Control "no-store, no-cache, must-revalidate";
+	}
+
+	location ~* \.(js|jpg|jpeg|gif|png|svg|css)$ {
+		add_header Cache-Control "max-age=31536000";
+	}
 
 	location /fwupdate/upload {
 		limit_except POST {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (2.1.2) stable; urgency=medium
+
+  * Disable client side caching of web-interface's index.html
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 01 Dec 2021 18:05:42 +0500
+
 wb-configs (2.1.1) stable; urgency=medium
 
   * remove old legacy sc16is7x2 module load (fix systemd-modules-load.service

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -58,3 +58,5 @@ if [[ -f /etc/motd ]] && [[ $(sha256sum /etc/motd | head -c 6) == 'a37897' ]]; t
     rm -f /etc/motd
     ln -s /var/run/motd /etc/motd
 fi
+
+deb-systemd-invoke reload nginx || true


### PR DESCRIPTION
К сожалению, тем, у кого браузер решил, что index.html можно показывать из кэша, надо будет один раз Ctrl+Shift+r нажать. Потом уже будут действовать настройки из Cache-Control.