### PR TITLE
fix race condition on /etc/network/interfaces during boot

### DIFF
--- a/configs/etc/wb-configs.d/01wb-configs
+++ b/configs/etc/wb-configs.d/01wb-configs
@@ -14,7 +14,13 @@ for f in passwd shadow group gshadow; do
 	wb_move_watch /etc/${f}
 done
 
-wb_move /etc/network/interfaces
+# There is a race condition between systemd-udev-trigger.service and mnt-data.mount
+# which may cause misconfiguration for interfaces with allow-hotplug
+# which are available on system boot (on-board Wi-Fi, for example).
+# This problem shoots on WB7 (fast hardware, huh).
+# So /etc/network/interfaces should be available before /mnt/data settles.
+wb_move_watch /etc/network/interfaces
+
 wb_move /etc/resolv.conf
 wb_move /etc/ssh
 wb_move /etc/dnsmasq.conf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-configs (2.3.1) stable; urgency=medium
+
+  * fix race condition on /etc/network/interfaces during boot
+    (the reason why Wi-Fi AP may not start properly on WB7 sometimes)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 12 Jan 2022 18:36:52 +0300
+
 wb-configs (2.3.0) stable; urgency=medium
 
   * add dependency on linux-image-wb7


### PR DESCRIPTION
It is the reason why Wi-Fi AP may not start properly on WB7 sometimes.

This fixes failing Wi-Fi AP mode on WB7.