### PR TITLE
Feature/38166 eth0 allow hotplug

### DIFF
--- a/configs/etc/network/interfaces.wb
+++ b/configs/etc/network/interfaces.wb
@@ -17,6 +17,7 @@ iface wlan0 inet static
 
 
 auto eth0
+allow-hotplug eth0
 iface eth0 inet dhcp
    pre-up wb-set-mac
    hostname WirenBoard
@@ -34,4 +35,3 @@ iface eth1 inet dhcp
 #iface ppp0 inet ppp
 ## select provider: megafon, mts or beeline below
 #  provider megafon
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (2.3.2) stable; urgency=medium
+
+  * interfaces: added "allow-hotplug" mode to eth0
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 4 Feb 2022 00:59:32 +0300
+
 wb-configs (2.3.1) stable; urgency=medium
 
   * fix race condition on /etc/network/interfaces during boot


### PR DESCRIPTION
Обсудили, allow-hotplug нужен

проверил, что:
1) при обновлении пакета interfaces остаётся тот, что и был
2) при установке образа - interfaces с allow-hotplug