### PR TITLE
more careful upgrade from legacy repository

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-configs (2.3.4) stable; urgency=medium
+
+  * add wb-configs-stretch pre-dependency on wb-update-manager
+  * remove transitional repo settings on successful wb-release invokation.
+    These changes should improve stability of upgrade from legacy repository
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 30 May 2022 14:24:55 +0300
+
 wb-configs (2.3.3) stable; urgency=medium
 
   * added "allow-hotplug" mode to eth0

--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,7 @@ Homepage: https://github.com/contactless/wb-configs
 Package: wb-configs
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1), inotify-tools, mosquitto (>= 1.4.7-1), watchdog (>= 5.15),
-         linux-image-wb2 | linux-image-wb6 | linux-image-wb7, wb-configs-stretch (>= ${binary:Version})
-Pre-Depends: wb-update-manager
+         linux-image-wb2 | linux-image-wb6 | linux-image-wb7, wb-update-manager, wb-configs-stretch (>= ${binary:Version})
 Provides: ${diverted-files}, mqtt-wss
 Conflicts: ${diverted-files}, mqtt-wss
 Recommends: wb-essential, wb-suite, figlet
@@ -19,6 +18,7 @@ Description: Default common config files for Wiren Board
 
 Package: wb-configs-stretch
 Architecture: all
+Pre-Depends: wb-update-manager
 Depends: systemd (>= 232-25), apt-transport-https, rsyslog
 Provides: ${diverted-files}
 Conflicts: ${diverted-files}, wb-homa-adc (<< 1.9.2), wb-homa-gpio (<< 1.14), wb-mqtt-serial(<< 1.14.2), wb-rules(<< 1.5.1), busybox-syslogd (<< 9:1.0~dummy)

--- a/debian/wb-configs-stretch.postinst
+++ b/debian/wb-configs-stretch.postinst
@@ -88,11 +88,13 @@ deb-systemd-invoke restart systemd-journald
 
 # remove transitional files left after 2.0~~transitional
 if echo "$2" | grep '~~transitional' >/dev/null; then
-    echo "Cleaning up transitional APT settings"
-    rm -f /etc/apt/preferences.d/00wirenboard-release-transition-tmp
-    rm -f /etc/apt/sources.list.d/wirenboard-release-transition-tmp.list
-    rm -f /etc/update-motd.d/99wb-upgrade-transition-tmp
+    remove_transitional_settings() {
+        echo "Cleaning up transitional APT settings"
+        rm -f /etc/apt/preferences.d/00wirenboard-release-transition-tmp
+        rm -f /etc/apt/sources.list.d/wirenboard-release-transition-tmp.list
+        rm -f /etc/update-motd.d/99wb-upgrade-transition-tmp
+    }
 
     echo "Generating new APT preferences according to installed release info"
-    wb-release -r
+    wb-release -r && remove_transitional_settings
 fi


### PR DESCRIPTION
  * add wb-configs-stretch pre-dependency on wb-update-manager
  * remove transitional repo settings on successful wb-release invokation.

These changes should improve stability of upgrade from legacy repository