### PR TITLE
Feature/41250 nginx no upload

### DIFF
--- a/configs/etc/nginx/sites-available/default.wb
+++ b/configs/etc/nginx/sites-available/default.wb
@@ -45,16 +45,18 @@ server {
 
 		gzip off;
 
-		track_uploads fwupdate 5s;
-
 		fastcgi_param UPLOADS_DIR /var/www/uploads;
 		fastcgi_param SCRIPT_FILENAME /usr/lib/cgi-bin/fwupdate_upload.py;
+		fastcgi_param SCRIPT_NAME fwupdate_upload.py;
 		fastcgi_param QUERY_STRING $query_string;
 		fastcgi_param REQUEST_METHOD $request_method;
 		fastcgi_param CONTENT_TYPE $content_type;
 		fastcgi_param CONTENT_LENGTH $content_length;
 		fastcgi_param REQUEST_URI $request_uri;
 		fastcgi_pass unix:/var/run/fcgiwrap.socket;
+		fastcgi_request_buffering off;
+
+		track_uploads fwupdate 5s;
 	}
 
 	location /fwupdate/progress {

--- a/configs/etc/nginx/sites-available/default.wb
+++ b/configs/etc/nginx/sites-available/default.wb
@@ -36,6 +36,31 @@ server {
 		add_header Cache-Control "max-age=31536000";
 	}
 
+	location /fwupdate/upload {
+		limit_except POST {
+			deny all;
+		}
+		client_body_buffer_size 128K;
+		client_max_body_size 1000M;
+
+		gzip off;
+
+		track_uploads fwupdate 5s;
+
+		fastcgi_param UPLOADS_DIR /var/www/uploads;
+		fastcgi_param SCRIPT_FILENAME /usr/lib/cgi-bin/fwupdate_upload.py;
+		fastcgi_param QUERY_STRING $query_string;
+		fastcgi_param REQUEST_METHOD $request_method;
+		fastcgi_param CONTENT_TYPE $content_type;
+		fastcgi_param CONTENT_LENGTH $content_length;
+		fastcgi_param REQUEST_URI $request_uri;
+		fastcgi_pass unix:/var/run/fcgiwrap.socket;
+	}
+
+	location /fwupdate/progress {
+		report_uploads fwupdate;
+	}
+
 	location /mqtt {
 	    proxy_pass http://localhost:18883;
 	    proxy_http_version 1.1;
@@ -43,4 +68,3 @@ server {
 	    proxy_set_header Connection upgrade;
 	}
 }
-

--- a/configs/etc/nginx/sites-available/default.wb
+++ b/configs/etc/nginx/sites-available/default.wb
@@ -17,6 +17,8 @@
 # Please see /usr/share/doc/nginx-doc/examples/ for more detailed examples.
 ##
 
+upload_progress fwupdate 1M;
+
 server {
 	#listen   80; ## listen for ipv4; this line is default and implied
 	#listen   [::]:80 default_server ipv6only=on; ## listen for ipv6
@@ -54,7 +56,7 @@ server {
 		fastcgi_param CONTENT_LENGTH $content_length;
 		fastcgi_param REQUEST_URI $request_uri;
 		fastcgi_pass unix:/var/run/fcgiwrap.socket;
-		fastcgi_request_buffering off;
+		fastcgi_request_buffering off;  # to allow stream-downloading via backend
 
 		track_uploads fwupdate 5s;
 	}

--- a/configs/usr/lib/cgi-bin/fwupdate_upload.py
+++ b/configs/usr/lib/cgi-bin/fwupdate_upload.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from cgi import FieldStorage
+
+
+RW_DIR = os.environ.get("UPLOADS_DIR", "/var/www/uploads")  # nginx user should have rw access
+os.makedirs(RW_DIR, exist_ok=True)
+
+
+def _error(msg=""):
+    sys.stdout.write("Status: 400 %s\r\n\r\n" % msg)
+    sys.exit(1)
+
+
+def to_chunks(fp, chunk_size=8192):
+    while True:
+        bs = fp.read(chunk_size)
+        if not bs:
+            break
+        yield bs
+
+
+form = FieldStorage(encoding="utf-8")
+uploading_file = form.get("file", None)
+if not uploading_file:
+    _error()
+
+if hasattr(uploading_file, "filename") and hasattr(uploading_file, "file"):
+    fname = uploading_file.filename or "fwupdate"
+    fp_upload = uploading_file.file
+else:
+    _error()
+
+with open(os.path.join(RW_DIR, fname), "wb") as fp_save:
+    for chunk in to_chunks(fp_upload):
+        fp_save.write(chunk)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.0.1) stable; urgency=medium
+
+  * nginx: change fwupdate-uploading backend from nginx upload module to python cgi
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 04 Jul 2022 09:37:21 +0300
+
 wb-configs (3.0.0) stable; urgency=medium
 
   * bullseye build

--- a/debian/control
+++ b/debian/control
@@ -9,10 +9,10 @@ Homepage: https://github.com/contactless/wb-configs
 Package: wb-configs
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1), inotify-tools, mosquitto (>= 1.4.7-1), watchdog (>= 5.15),
-         linux-image-wb2 | linux-image-wb6 | linux-image-wb7, wb-update-manager, wb-configs-stretch (>= ${binary:Version})
+         linux-image-wb2 | linux-image-wb6 | linux-image-wb7, fcgiwrap, wb-update-manager, wb-configs-stretch (>= ${binary:Version})
 Pre-Depends: wb-update-manager
 Provides: ${diverted-files}, mqtt-wss
-Conflicts: ${diverted-files}, mqtt-wss, wb-homa-adc (<< 1.9.2), wb-homa-gpio (<< 1.14), wb-mqtt-serial(<< 1.14.2), wb-rules(<< 1.5.1), busybox-syslogd (<< 9:1.0~dummy)
+Conflicts: ${diverted-files}, mqtt-wss, wb-homa-adc (<< 1.9.2), wb-homa-gpio (<< 1.14), wb-mqtt-serial(<< 1.14.2), wb-rules(<< 1.5.1), busybox-syslogd (<< 9:1.0~dummy), nginx-common (<< 1.7.11)
 Recommends: wb-essential, wb-suite, figlet
 Replaces: mqtt-wss
 Description: Default common config files for Wiren Board

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/contactless/wb-configs
 
 Package: wb-configs
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1), inotify-tools, mosquitto (>= 1.4.7-1), watchdog (>= 5.15),
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 3.7.0), inotify-tools, mosquitto (>= 1.4.7-1), watchdog (>= 5.15),
          linux-image-wb2 | linux-image-wb6 | linux-image-wb7, fcgiwrap, wb-update-manager, wb-configs-stretch (>= ${binary:Version})
 Pre-Depends: wb-update-manager
 Provides: ${diverted-files}, mqtt-wss

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -2,7 +2,7 @@
 . /usr/lib/wb-utils/wb_env.sh
 wb_source "of"
 
-# generate u-boot env config before config-package debheler 
+# generate u-boot env config before config-package debheler
 UBOOT_DIR="/usr/share/wb-configs/u-boot"
 UBOOT_FNAME="fw_env.config.wb"
 if of_machine_match "allwinner,sun8i-r40"; then
@@ -174,4 +174,11 @@ if echo "$2" | grep '~~transitional' >/dev/null; then
 
     echo "Generating new APT preferences according to installed release info"
     wb-release -r
+fi
+
+# nginx user should has rw access to fwupdate uploads dir
+local nginx_uploads_dir="/mnt/data/uploads"
+local nginx_user="www-data"
+if [[ -d $nginx_uploads_dir ]] && [[ id -u ${nginx_user} > /dev/null 2>&1 ]]; then
+    chown -R ${nginx_user}:${nginx_user} ${nginx_uploads_dir}
 fi

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -177,8 +177,9 @@ if echo "$2" | grep '~~transitional' >/dev/null; then
 fi
 
 # nginx user should has rw access to fwupdate uploads dir
-local nginx_uploads_dir="/mnt/data/uploads"
-local nginx_user="www-data"
-if [[ -d $nginx_uploads_dir ]] && [[ id -u ${nginx_user} > /dev/null 2>&1 ]]; then
-    chown -R ${nginx_user}:${nginx_user} ${nginx_uploads_dir}
+nginx_uploads_dir="/mnt/data/uploads"
+nginx_user="www-data"
+if [[ -d $nginx_uploads_dir ]] && $(id -u $nginx_user > /dev/null 2>&1); then
+    echo "Setting ownership $nginx_user to $nginx_uploads_dir"
+    chown -R $nginx_user:$nginx_user $nginx_uploads_dir
 fi


### PR DESCRIPTION
Задумка - отказаться от модуля "upload" нжинкса, т.к. его нет в пакетах и надо собирать.

Раньше: нжинкс (модулем upload) самостоятельно разбирал post на fwupdate/upload и сохранял файлик в /var/www/uploads (самостоятельно создавая папку от юзера www-data). Когда скачалось - возвращаем 200. С другого конца, фронт смотрит в 200 (и говорит, мол загрузилось) и в логи/статус через mqtt (пишет wb-run-update). Нужно для прогрессбара загрузки.

Стало: загружаем файлики через cgi питоном. Нжинкс кладет запрос в сокет fcgiwrap, откуда запускается питон с данными в stdin/out и переменными окружения из fastcgi_param *.

Проблемы:

- права. Раньше папка загрузок создавалась модулем нжинкса (подозреваю, при его старте). Сейчас же питон не дергается, пока не прилетел запрос => из-за логики wb_move_* в wb-configs получаем права root:root на папку. Решение - chown в postinst
- буферизация. Nginx => cgi отключается конфигом (что и сделано); в результате - шлёт байтики в cgi налету. Cgi => nginx. Не отключается никак (не смотря на ручки в nginx и fcgiwrap; проблема довольно распространена). У нас это ломает прогрессбар загрузки на фронте. Wb-watch-update видит файл (и пишет статус/логи) раньше, чем кончился cgi-скрипт => фронт перезатирает ругательства wb-watch-update (на неправильный файл) в статусбаре выхлопом cgi (или сообщением нжинкса, что его нет:)). Решение - [pr с задержкой в wb-watch-update](https://github.com/wirenboard/wb-utils/pull/42). Или лезть во фронт и делать приоритет статуса из mqtt (мне не нравится)
