### PR TITLE
fix broken debug console login on Wiren Board 7

### DIFF
--- a/configs/etc/systemd/system/serial-getty@ttyS0.service.d/override.conf
+++ b/configs/etc/systemd/system/serial-getty@ttyS0.service.d/override.conf
@@ -1,2 +1,3 @@
 [Service]
+ExecStart=
 ExecStart=-/sbin/agetty -o '-p -- \\u' --keep-baud %I $TERM

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.0.2) stable; urgency=medium
+
+  * fix broken debug console login on Wiren Board 7
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 19 Sep 2022 10:46:42 +0300
+
 wb-configs (3.0.1) stable; urgency=medium
 
   * nginx: change fwupdate-uploading backend from nginx upload module to python cgi


### PR DESCRIPTION
Тянется из #57, там не совсем правильно был написан `override.conf` для сервиса `serial-getty@ttyS0.service`. systemd ругался на две директивы `ExecStart`. В примере по ссылке в описании коммита (https://github.com/systemd/systemd/issues/15611) в `override.conf` сначала надо было написать `ExecStart=`, чтобы сбросить старое значение. После этого логин через консоль у меня заработал.