### PR TITLE
add apt pin to install modemmanager dependencies from backports

### DIFF
--- a/configs/etc/apt/preferences.d/50backports
+++ b/configs/etc/apt/preferences.d/50backports
@@ -1,0 +1,3 @@
+Package: libnm0 libmbim-*:any libqmi-*:any gir1.2-mbim-1.0 gir1.2-qmi-1.0
+Pin: release a=bullseye-backports
+Pin-Priority: 510

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.2.0) stable; urgency=medium
+
+  * add apt pin to install modemmanager dependencies from backports
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 20 Sep 2022 13:07:32 +0300
+
 wb-configs (3.1.0) stable; urgency=medium
 
   * Add ModemManager and NetworkManager support


### PR DESCRIPTION
Этих пинов не хватает для того, чтобы установить build-deps при сборке, и обычные зависимости на контроллере