### PR TITLE
wrap mosquitto tools into our script to add --unix arg

### DIFF
--- a/configs/root/.config/mosquitto_pub.wb
+++ b/configs/root/.config/mosquitto_pub.wb
@@ -1,1 +1,0 @@
---unix /var/run/mosquitto/mosquitto.sock

--- a/configs/root/.config/mosquitto_sub.wb
+++ b/configs/root/.config/mosquitto_sub.wb
@@ -1,1 +1,0 @@
---unix /var/run/mosquitto/mosquitto.sock

--- a/configs/usr/bin/mosquitto_pub
+++ b/configs/usr/bin/mosquitto_pub
@@ -1,0 +1,1 @@
+wb-mosquitto-tools-wrapper

--- a/configs/usr/bin/mosquitto_rr
+++ b/configs/usr/bin/mosquitto_rr
@@ -1,0 +1,1 @@
+wb-mosquitto-tools-wrapper

--- a/configs/usr/bin/mosquitto_sub
+++ b/configs/usr/bin/mosquitto_sub
@@ -1,0 +1,1 @@
+wb-mosquitto-tools-wrapper

--- a/configs/usr/bin/wb-mosquitto-tools-wrapper
+++ b/configs/usr/bin/wb-mosquitto-tools-wrapper
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This wrapper script adds arguments for mosquitto utils
+# to connect via UNIX socket in case
+# if no special connection settings are provided.
+
+ORIG_TOOL="$0.mosq"
+DEFAULT_ARGS=("--unix" "/var/run/mosquitto/mosquitto.sock")
+
+for arg in "$@"; do
+case "$arg" in
+    -h|-p|--unix)  # connection settings are specified via arguments
+        exec $ORIG_TOOL "$@"
+esac
+done
+
+exec "$ORIG_TOOL" "${DEFAULT_ARGS[@]}" "$@"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.4.0) stable; urgency=medium
+
+  * wrap mosquitto tools into our script to pass UNIX socket by default
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 26 Oct 2022 13:08:33 +0600
+
 wb-configs (3.3.0) stable; urgency=medium
 
   * Fix networking.service symlink in bullseye by removing networking.service.wb

--- a/debian/wb-configs.displace
+++ b/debian/wb-configs.displace
@@ -1,6 +1,4 @@
 /root/.bashrc.wb
-/root/.config/mosquitto_sub.wb
-/root/.config/mosquitto_pub.wb
 /etc/locale.gen.wb
 /etc/hostname.wb
 /etc/modules.wb

--- a/debian/wb-configs.postrm
+++ b/debian/wb-configs.postrm
@@ -17,3 +17,23 @@ if [ "$1" = "purge" ]; then
 fi
 
 udevadm trigger # apply new udev rules
+
+# restore original mosquitto scripts
+# the same section is in preinst script
+mosquitto_apps=("mosquitto_sub" "mosquitto_pub" "mosquitto_rr")
+for file in "${mosquitto_apps[@]}"; do
+
+    # During remove/purge, postrm script runs after old files are deleted.
+    # When upgrading, it runs _before_ it.
+    # It's not a problem if upgrade keeps divertion of mosquitto tools,
+    # but breaks them on downgrade.
+
+    if [[ "$1" = "upgrade" ]] && dpkg --compare-versions "$2" lt "3.4.0~~"; then
+        echo "WARNING: downgrading from mosquitto-wrapping version, remove wrappers"
+        rm -f "/usr/bin/${file}"
+    fi
+
+    if [[ ! -e "/usr/bin/${file}" ]]; then
+        dpkg-divert --package wb-configs --rename --remove "/usr/bin/${file}"
+    fi
+done

--- a/debian/wb-configs.preinst
+++ b/debian/wb-configs.preinst
@@ -79,4 +79,13 @@ fi
 
 deb-systemd-invoke stop watchdog
 
+# divert /usr/bin/mosquitto_pub, /usr/bin/mosquitto_sub to use our wrapper scripts
+# the same section is in postrm script
+mosquitto_apps=("mosquitto_sub" "mosquitto_pub" "mosquitto_rr")
+for file in "${mosquitto_apps[@]}"; do
+    if [[ ! -e "/usr/bin/${file}.mosq" ]]; then
+       dpkg-divert --package wb-configs --divert "/usr/bin/${file}.mosq" --rename "/usr/bin/${file}"
+    fi
+done
+
 #DEBHELPER#

--- a/debian/wb-configs.undisplace
+++ b/debian/wb-configs.undisplace
@@ -1,2 +1,4 @@
 /etc/ssh/sshd_config.wb
 /lib/systemd/system/networking.service.wb
+/root/.config/mosquitto_sub.wb
+/root/.config/mosquitto_pub.wb


### PR DESCRIPTION
Изначально при переходе на новый mosquitto я добавил в `/root` конфиги для `mosquitto_pub` и `mosquitto_sub`, чтобы они по умолчанию подключались через UNIX-сокет. Это решение мне не очень нравится архитектурно, а ещё оно оказалось неудобно, потому что иногда вызывало проблемы при обновлении (писало ошибки вокруг этих файлов конфигов). Также такое решение ломало бы пользовательские настройки (если кто-то решит настроить mosquitto_pub/sub самостоятельно, хоть и вряд ли таких случаев много).

Хорошим решением было бы пропатчить утилиты mosquitto, чтобы они воспринимали конфиги из какой-нибудь системной локации, но по-моему это чревато сложностями при обновлении и никому, кроме нас, не нужно.

В итоге я подумал и решил, что можно подменить испролняемые файлы mosquitto_pub/sub/rr через тот же dpkg-divert. Вместо них я подложил скрипт-прослойку, который проверяет аргументы командной строки, и если там нет явных настроек соединения (host, port или socket), то подставляет по умолчанию аргументы для подключения через наш сокет и вызывает оригинальную версию утилиты.

Так делают, в статьях про dpkg-divert даже приводят ровно такой пример использования (https://www.debianadmin.com/replace-binaries-and-files-with-dpkg-divert.html)

Не должно сломаться при обновлении mosquitto.