### PR TITLE
Auto-mount MicroSD to /mnt/sdcard

### DIFF
--- a/configs/etc/fstab.wb
+++ b/configs/etc/fstab.wb
@@ -1,6 +1,6 @@
 /dev/mmcblk0p2   /           auto   errors=remount-ro,noatime   0   1
 /dev/mmcblk0p5   none        swap   errors=remount-ro           0   0
 /dev/mmcblk0p6  /mnt/data    auto   nofail                      0   2
-/dev/mmcblk1p1  /mnt/sdcard  auto   nofail                      0   2
+/dev/mmcblk1p1  /mnt/sdcard  auto   nofail,x-systemd.automount,x-systemd.device-timeout=2  0   2
 /mnt/data/var/log  /var/log  none   bind                        0   0
 configfs /sys/kernel/config configfs defaults 0 0

--- a/configs/etc/fstab.wb
+++ b/configs/etc/fstab.wb
@@ -1,5 +1,6 @@
 /dev/mmcblk0p2   /           auto   errors=remount-ro,noatime   0   1
 /dev/mmcblk0p5   none        swap   errors=remount-ro           0   0
 /dev/mmcblk0p6  /mnt/data    auto   nofail                      0   2
+/dev/mmcblk1p1  /mnt/sdcard  auto   nofail                      0   2
 /mnt/data/var/log  /var/log  none   bind                        0   0
 configfs /sys/kernel/config configfs defaults 0 0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.5.2) UNRELEASED; urgency=medium
+
+  * Auto-mount MicroSD to /mnt/sdcard
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 19 Dec 2022 11:14:00 +0400
+
 wb-configs (3.5.1) UNRELEASED; urgency=medium
 
   * Fix dnsmasq warning when using shared connections in NetworkManager


### PR DESCRIPTION
https://wirenboard.com/wiki/Wiren_Board_7#%D0%A1%D0%BB%D0%BE%D1%82_MicroSD
Монтируем только первый раздел для простоты (в большинстве случаев он один), чтобы не тянуть новые зависимости (udisks2 и пр).