### PR TITLE
enable wlan1 in NetworkManager

### DIFF
--- a/configs/usr/lib/NetworkManager/conf.d/wb.conf
+++ b/configs/usr/lib/NetworkManager/conf.d/wb.conf
@@ -1,7 +1,7 @@
 [keyfile]
 # usb0 - RNDIS interface from GSM-modem, it is not supported by ModemManager, so ignore it too
 # Simultaneous connection on wlan0 and network scan on wlan1 can lead to connection errors, so just ignore wlan1 
-unmanaged-devices=interface-name:usb0;interface-name:wlan1;
+unmanaged-devices=interface-name:usb0;
 
 [device]
 wifi.scan-rand-mac-address=no

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.8.0) stable; urgency=medium
+
+  * Enable wlan1 in NetworkManager
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 28 Dec 2022 16:35:01 +0600
+
 wb-configs (3.7.0) UNRELEASED; urgency=medium
 
   * Auto-mount MicroSD to /mnt/sdcard

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/contactless/wb-configs
 Package: wb-configs
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 4.1.0), inotify-tools, mosquitto (>= 1.4.7-1), watchdog (>= 5.15),
-         linux-image-wb2 | linux-image-wb6 | linux-image-wb7, fcgiwrap, wb-update-manager
+         linux-image-wb2 | linux-image-wb6 (>= 5.10.35-wb127~~) | linux-image-wb7 (>= 5.10.35-wb127~~), fcgiwrap, wb-update-manager
 Pre-Depends: wb-update-manager
 Provides: ${diverted-files}, mqtt-wss
 Conflicts: ${diverted-files}, mqtt-wss, wb-homa-adc (<< 1.9.2), wb-homa-gpio (<< 1.14), wb-mqtt-serial(<< 1.14.2), wb-rules(<< 1.5.1), busybox-syslogd (<< 9:1.0~dummy), nginx-common (<< 1.7.11)


### PR DESCRIPTION
Для того, чтобы сеть при этом не ломалась, требуется ядро с правками в драйвере (не старше 5.10.35-wb127)