### PR TITLE
Manage external USB RNDIS via NetworkManager + fix PPP breaking resolv.conf

### DIFF
--- a/configs/etc/ppp/ip-up.d/0000usepeerdns.wb
+++ b/configs/etc/ppp/ip-up.d/0000usepeerdns.wb
@@ -1,0 +1,47 @@
+#!/bin/sh -e
+
+# This script is backported for Wiren Board from ppp 2.4.9-1+1.1.
+# It handles NetworkManager properly and does not rewrite resolv.conf.
+
+# this variable is only set if the usepeerdns pppd option is being used
+[ "$USEPEERDNS" ] || exit 0
+
+# exit if the resolvconf package is installed
+[ -x /sbin/resolvconf ] && exit 0
+
+# exit if systemd-resolved is running
+[ -e /run/systemd/system ] && \
+  systemctl is-active --quiet systemd-resolved.service &&
+  exit 0
+
+case "$6" in
+  nm-*-service-*|/org/freedesktop/NetworkManager/PPP/*)
+        # NetworkManager handles it
+        exit 0
+        ;;
+esac
+
+# create the file if it does not exist
+if [ ! -e /etc/resolv.conf ]; then
+  : > /etc/resolv.conf
+fi
+
+# follow any symlink to find the real file
+REALRESOLVCONF=$(readlink --canonicalize /etc/resolv.conf)
+
+# merge the new nameservers with the other options from the old configuration
+{
+  cat /etc/ppp/resolv.conf
+  grep --invert-match '^nameserver[[:space:]]' "$REALRESOLVCONF" || true
+} > "$REALRESOLVCONF.tmp"
+
+# backup the old configuration and install the new one
+cp -a "$REALRESOLVCONF" "$REALRESOLVCONF.pppd-backup.$PPP_IFACE"
+mv -f "$REALRESOLVCONF.tmp" "$REALRESOLVCONF"
+
+# restart nscd because resolv.conf has changed
+if [ -e /var/run/nscd.pid ]; then
+  /etc/init.d/nscd restart || true
+fi
+
+exit 0

--- a/configs/etc/udev/rules.d/99-wb-modem.rules
+++ b/configs/etc/udev/rules.d/99-wb-modem.rules
@@ -4,7 +4,7 @@ GOTO="wb_modem_end"
 
 LABEL="wb_modem_types"
 
-# SIMCOM A7600E-H SIM switch
-ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+# SIMCOM A7600E-H SIM switch and mark RNDIS unmanaged for NetworkManager
+ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT", ENV{NM_UNMANAGED}="1"
 
 LABEL="wb_modem_end"

--- a/configs/usr/lib/NetworkManager/conf.d/wb.conf
+++ b/configs/usr/lib/NetworkManager/conf.d/wb.conf
@@ -1,8 +1,3 @@
-[keyfile]
-# usb0 - RNDIS interface from GSM-modem, it is not supported by ModemManager, so ignore it too
-# Simultaneous connection on wlan0 and network scan on wlan1 can lead to connection errors, so just ignore wlan1 
-unmanaged-devices=interface-name:usb0;
-
 [device]
 wifi.scan-rand-mac-address=no
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.9.4) stable; urgency=medium
+
+  * Mark WB modem RNDIS as unmanaged via udev (fix external usb0 connections)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 10 Jan 2023 19:44:44 +0600
+
 wb-configs (3.9.3) stable; urgency=medium
 
   * Backup NetworkManager connections during update using fit 

--- a/debian/wb-configs.displace
+++ b/debian/wb-configs.displace
@@ -14,6 +14,7 @@
 /etc/watchdog.conf.wb
 
 /etc/ppp/chap-secrets.wb
+/etc/ppp/ip-up.d/0000usepeerdns.wb
 
 /etc/nginx/sites-available/default.wb
 /etc/nfc/libnfc.conf.wb


### PR DESCRIPTION
 - backport ppp ip-up.d script from Debian bookworm (can't backport the whole package because of dependencies on libssl3 and newer libc) to fix resolv.conf rewriting by PPP (breaks DNS resolving when modem connection is up)
 - allow `usb0` interface in NetworkManager (was denied previously to keep internal modem RNDIS untouched). Internal modem is marked as unmanaged in udev. Now external RNDIS devices (e.g. Android phones as USB modems) work out of the box.