### PR TITLE
ModemManager starts before ifupdown-pre

### DIFF
--- a/configs/etc/systemd/system/ModemManager.service.d/override.conf
+++ b/configs/etc/systemd/system/ModemManager.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+# MM should be started before any wb-gsm call (wb-gsm could stop MM due to internal assumptions)
+Before=ifupdown-pre.service

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.13.2) stable; urgency=medium
+
+  * ModemManager starts before ifupdown-pre
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 27 Mar 2023 11:20:28 +0300
+
 wb-configs (3.13.1) stable; urgency=medium
 
   * Add WBGSM_INTERACTIVE env var to /etc/profile.d


### PR DESCRIPTION
На демо заметили, что если в /etc/network/interfaces прописан ppp, то через webui можно включить sim1, и начнется борьба wb-gsm и MM.

Раздебажил, причина - после загрузки wb, MM не остановлен, т.к. стартует позже вызовов wb-gsm, направленных на его прибитие.
Воткнул 3g-модем; логика "управляется ли модем через MM (которая udev-правилами)" не сломалась