### PR TITLE
Disable ModemManager if ppp is configured in interfaces

### DIFF
--- a/configs/lib/systemd/system/ModemManager.service.d/override.conf
+++ b/configs/lib/systemd/system/ModemManager.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecCondition=/usr/lib/wb-configs/detect_legacy_modem_config.sh

--- a/configs/usr/lib/wb-configs/detect_legacy_modem_config.sh
+++ b/configs/usr/lib/wb-configs/detect_legacy_modem_config.sh
@@ -17,12 +17,12 @@ provider_has_wbgsm() {
 for ppp_string in "${ppp_strings[@]}"; do
 case "$ppp_string" in
 explicit_wbgsm_call)
-    echo "Explicit wb-gsm call found in ppp interface configured in /etc/network/interfaces, disabling ModemManager"
+    echo "Explicit wb-gsm call found in ppp interface configured in /etc/network/interfaces, not starting ModemManager"
     exit 1;
     ;;
 *)
     if provider_has_wbgsm "$ppp_string"; then
-        echo "wb-gsm is called in provider $ppp_string used in /etc/network/interfaces, disabling ModemManager"
+        echo "wb-gsm is called in provider $ppp_string used in /etc/network/interfaces, not starting ModemManager"
         exit 1;
     fi
     ;;

--- a/configs/usr/lib/wb-configs/detect_legacy_modem_config.sh
+++ b/configs/usr/lib/wb-configs/detect_legacy_modem_config.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This script detects if there is a PPP interface
+# configured in /etc/network/interfaces either
+# with explicit wb-gsm call (ensures it is an internal modem)
+# or with provider which calls wb-gsm explictly
+
+readarray -t ppp_strings < <(awk -v ppp="ppp" '/^iface/ && $4==ppp {f=1} /^iface/ && $4!=ppp {f=0} \
+    f && /^[[:space:]]*pre-up.*wb-gsm/ {print "explicit_wbgsm_call"} \
+    f && /^[[:space:]]*provider/ {print $2}' /etc/network/interfaces)
+
+provider_has_wbgsm() {
+    echo "Checking if provider $1 uses wb-gsm in init"
+    grep -q '^init.*wb-gsm' "/etc/ppp/peers/$1"
+}
+
+for ppp_string in "${ppp_strings[@]}"; do
+case "$ppp_string" in
+explicit_wbgsm_call)
+    echo "Explicit wb-gsm call found in ppp interface configured in /etc/network/interfaces, disabling ModemManager"
+    exit 1;
+    ;;
+*)
+    if provider_has_wbgsm "$ppp_string"; then
+        echo "wb-gsm is called in provider $ppp_string used in /etc/network/interfaces, disabling ModemManager"
+        exit 1;
+    fi
+    ;;
+esac
+done
+
+exit 0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-configs (3.14.1) stable; urgency=medium
+
+  * do not start ModemManager explicitly if modem is configured via
+    /etc/network/interfaces
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 28 Mar 2023 19:10:38 +0600
+
 wb-configs (3.14.0) stable; urgency=medium
 
   Add feature to download rootfs archive via web UI

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,7 +7,7 @@ wb-configs (3.14.1) stable; urgency=medium
 
 wb-configs (3.14.0) stable; urgency=medium
 
-  Add feature to download rootfs archive via web UI
+  * Add feature to download rootfs archive via web UI
 
  -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Tue, 14 Mar 2023 21:14 +0600
 


### PR DESCRIPTION
 - немного ускоряет загрузку контроллера, поскольку ModemManager не запускается почём зря
 - не даёт случиться драке между pppd и ModemManager при сохранении конфига сети через web-интерфейс