### PR TITLE
hide wb-gsm-sim1 and wb-gsm-sim2 in webui untill modem is not enabled

### DIFF
--- a/configs/usr/lib/NetworkManager/system-connections/wb-gsm-sim1.nmconnection
+++ b/configs/usr/lib/NetworkManager/system-connections/wb-gsm-sim1.nmconnection
@@ -4,6 +4,9 @@ uuid=5d4297ba-c319-4c05-a153-17cb42e6e196
 type=gsm
 autoconnect=false
 
+[user]
+wb.read-only=true
+
 [gsm]
 auto-config=true
 sim-slot=1

--- a/configs/usr/lib/NetworkManager/system-connections/wb-gsm-sim2.nmconnection
+++ b/configs/usr/lib/NetworkManager/system-connections/wb-gsm-sim2.nmconnection
@@ -4,6 +4,9 @@ uuid=8b9964d4-b8dd-34d3-a3ed-481840bcf8c9
 type=gsm
 autoconnect=false
 
+[user]
+wb.read-only=true
+
 [gsm]
 auto-config=true
 sim-slot=2

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.14.1) stable; urgency=medium
+
+  * Hide wb-gsm-sim1 and wb-gsm-sim2 in webui untill modem is not enabled
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 28 Mar 2023 16:57:12 +0300
+
 wb-configs (3.14.0) stable; urgency=medium
 
   Add feature to download rootfs archive via web UI


### PR DESCRIPTION
решили sim-соединения сделать скрытыми по умолчанию

показываем их хуками hwconf'a через отдельную тулзу в wb-nm-helper'e