### PR TITLE
forbid wb-release-info installation from testing sets

### DIFF
--- a/configs/etc/apt/preferences.d/40wb-experimental
+++ b/configs/etc/apt/preferences.d/40wb-experimental
@@ -1,3 +1,7 @@
 Package: *
 Pin: release o=wirenboard,a=experimental.*
 Pin-Priority: 991
+
+Package: wb-release-info
+Pin: release o=wirenboard,a=experimental.*
+Pin-Priority: -1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.15.1) stable; urgency=medium
+
+  * forbid wb-release-info installation from testing sets
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 12 Apr 2023 12:27:13 +0600
+
 wb-configs (3.15.0) stable; urgency=medium
 
   * fwupdate_upload: single rootfs update scheme support


### PR DESCRIPTION
Связано с багом в wbci, из-за которого в testing set-ы добавляется пакет wb-release-info, из-за которого может испортиться `/etc/apt/sources.list.d/wirenboard.list` при сборке rootfs (там останется только этот testing set, основной репозиторий удалится)