### PR TITLE
fwupdate_upload: single rootfs update scheme support (#108)

### DIFF
--- a/configs/usr/lib/cgi-bin/fwupdate_upload.py
+++ b/configs/usr/lib/cgi-bin/fwupdate_upload.py
@@ -5,8 +5,11 @@ import sys
 import tempfile
 from cgi import FieldStorage
 
+if os.path.islink("/var/run/wb-watch-update.dir"):
+    RW_DIR = os.path.realpath("/var/run/wb-watch-update.dir")
+else:
+    RW_DIR = os.environ.get("UPLOADS_DIR", "/var/www/uploads")  # nginx user should has rw access
 
-RW_DIR = os.environ.get("UPLOADS_DIR", "/var/www/uploads")  # nginx user should has rw access
 TMP_DIR = os.path.join(RW_DIR, "state", "tmp")  # excluded from wb-watch-update
 os.makedirs(TMP_DIR, exist_ok=True)
 
@@ -31,12 +34,11 @@ class DiskFieldStorage(FieldStorage):
     """
 
     def make_file(self):
-        location = TMP_DIR # has rw access & excluded from wb-watch-update
+        location = TMP_DIR  # has rw access & excluded from wb-watch-update
         if self._binary_file:
             return tempfile.TemporaryFile("wb+", dir=location)
         else:
-            return tempfile.TemporaryFile("w+",
-                encoding=self.encoding, newline = '\n', dir=location)
+            return tempfile.TemporaryFile("w+", encoding=self.encoding, newline="\n", dir=location)
 
 
 form = DiskFieldStorage(encoding="utf-8")

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.13.1-wb102) stable; urgency=medium
+
+  * fwupdate_upload: single rootfs update scheme support
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 20 Apr 2023 19:03:31 +0600
+
 wb-configs (3.13.1-wb101) stable; urgency=medium
 
   * set Wi-Fi AP channel to 1 explicitly (channels 6 and 13 seems to be


### PR DESCRIPTION
* fwupdate_upload: use dir defined by wb-watch-update if it exists
* fwupdate_upload: fix python formatting

Backport of #108 