### PR TITLE
add debian-security from archive to prevent downgrades

### DIFF
--- a/configs-stretch/etc/apt/sources.list.d/debian-upstream.list
+++ b/configs-stretch/etc/apt/sources.list.d/debian-upstream.list
@@ -1,1 +1,2 @@
 deb http://archive.debian.org/debian/ stretch main
+deb http://archive.debian.org/debian-security/ stretch/updates main

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (2.3.4-wb103) stable; urgency=medium
+
+  * add debian-security from archive to prevent downgrades
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 25 Apr 2023 12:04:46 +0600
+
 wb-configs (2.3.4-wb102) stable; urgency=medium
 
   * stretch repos moved to archive.debian.org


### PR DESCRIPTION
@lostpoint-ru был прав, часть пакетов из debian-security не слилась с основным релизом. Нашёл адрес, добавил в список