### PR TITLE
udev: add specific tag to WB-internal modems

### DIFF
--- a/configs/etc/udev/rules.d/99-wb-modem.rules
+++ b/configs/etc/udev/rules.d/99-wb-modem.rules
@@ -3,6 +3,14 @@ SUBSYSTEMS=="usb", GOTO="wb_usb_modem_types"
 
 LABEL="wb_usb_modem_types"
 
+# Add tag to WB internal modems
+ENV{OF_COMPATIBLE_0}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
+ENV{OF_COMPATIBLE_1}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
+ENV{OF_COMPATIBLE_2}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
+ENV{OF_COMPATIBLE_3}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
+ENV{OF_COMPATIBLE_4}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
+ENV{OF_COMPATIBLE_5}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
+
 # SIMCOM SIM800C-DS: ignore
 ATTRS{idVendor}=="0e8d", ATTRS{idProduct}=="0003", ENV{ID_MM_DEVICE_IGNORE}="1"
 # SIMCOM SIM5300E: ignore
@@ -10,11 +18,8 @@ ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="0020", ENV{ID_MM_DEVICE_IGNORE}="1"
 # SIMCOM SIM7000E: ignore
 ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9001", ENV{ID_MM_DEVICE_IGNORE}="1"
 # SIMCOM A7600E-H: SIM switch and mark RNDIS unmanaged for NetworkManager
-ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT", ENV{NM_UNMANAGED}="1"
+ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{ID_MM_PHYSDEV_UID}=="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT", ENV{NM_UNMANAGED}="1"
 # QUECTEL EC200T-EU: SIM switch and mark RNDIS unmanaged for NetworkManager
 ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="6026", ENV{ID_MM_DEVICE_IGNORE}="1"
-
-# Add tag to WB internal modems
-ENV{OF_COMPATIBLE_0}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
 
 LABEL="wb_modem_end"

--- a/configs/etc/udev/rules.d/99-wb-modem.rules
+++ b/configs/etc/udev/rules.d/99-wb-modem.rules
@@ -14,4 +14,7 @@ ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{ID_MM_SIM_SWITCH_GPIO_LAB
 # QUECTEL EC200T-EU: SIM switch and mark RNDIS unmanaged for NetworkManager
 ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="6026", ENV{ID_MM_DEVICE_IGNORE}="1"
 
+# Add tag to WB internal modems
+ENV{OF_COMPATIBLE_0}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
+
 LABEL="wb_modem_end"

--- a/configs/etc/udev/rules.d/99-wb-modem.rules
+++ b/configs/etc/udev/rules.d/99-wb-modem.rules
@@ -3,13 +3,13 @@ SUBSYSTEMS=="usb", GOTO="wb_usb_modem_types"
 
 LABEL="wb_usb_modem_types"
 
-# Add tag to WB internal modems
-ENV{OF_COMPATIBLE_0}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
-ENV{OF_COMPATIBLE_1}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
-ENV{OF_COMPATIBLE_2}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
-ENV{OF_COMPATIBLE_3}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
-ENV{OF_COMPATIBLE_4}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
-ENV{OF_COMPATIBLE_5}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc"
+# WB-internal modems have simselect gpio and specific tag (mmcli -m tag)
+ENV{OF_COMPATIBLE_0}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+ENV{OF_COMPATIBLE_1}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+ENV{OF_COMPATIBLE_2}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+ENV{OF_COMPATIBLE_3}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+ENV{OF_COMPATIBLE_4}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+ENV{OF_COMPATIBLE_5}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
 
 # SIMCOM SIM800C-DS: ignore
 ATTRS{idVendor}=="0e8d", ATTRS{idProduct}=="0003", ENV{ID_MM_DEVICE_IGNORE}="1"
@@ -18,7 +18,7 @@ ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="0020", ENV{ID_MM_DEVICE_IGNORE}="1"
 # SIMCOM SIM7000E: ignore
 ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9001", ENV{ID_MM_DEVICE_IGNORE}="1"
 # SIMCOM A7600E-H: SIM switch and mark RNDIS unmanaged for NetworkManager
-ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{ID_MM_PHYSDEV_UID}=="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT", ENV{NM_UNMANAGED}="1"
+ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{NM_UNMANAGED}="1"
 # QUECTEL EC200T-EU: SIM switch and mark RNDIS unmanaged for NetworkManager
 ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="6026", ENV{ID_MM_DEVICE_IGNORE}="1"
 

--- a/configs/etc/udev/rules.d/99-wb-modem.rules
+++ b/configs/etc/udev/rules.d/99-wb-modem.rules
@@ -17,9 +17,9 @@ ATTRS{idVendor}=="0e8d", ATTRS{idProduct}=="0003", ENV{ID_MM_DEVICE_IGNORE}="1"
 ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="0020", ENV{ID_MM_DEVICE_IGNORE}="1"
 # SIMCOM SIM7000E: ignore
 ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9001", ENV{ID_MM_DEVICE_IGNORE}="1"
-# SIMCOM A7600E-H: SIM switch and mark RNDIS unmanaged for NetworkManager
+# SIMCOM A7600E-H: mark RNDIS unmanaged for NetworkManager
 ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{NM_UNMANAGED}="1"
-# QUECTEL EC200T-EU: SIM switch and mark RNDIS unmanaged for NetworkManager
+# QUECTEL EC200T-EU: ignore
 ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="6026", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 LABEL="wb_modem_end"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-configs (3.16.0) stable; urgency=medium
 
-  * Udev: add specific tag ("wbc") to WB-internal modems
+  * Udev: add ModemManager specific tag ("wbc") to WB-internal modems. mmcli -m wbc could be used to manage the modem
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 04 May 2023 13:36:12 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.15.4) stable; urgency=medium
+
+  * Udev: add specific tag to WB-internal modems
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 04 May 2023 13:36:12 +0300
+
 wb-configs (3.15.3) stable; urgency=medium
 
   * Add /usr/lib/systemd/ntp-units.d/10-ntp.list to make timedatectl aware of ntp.service

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-configs (3.15.4) stable; urgency=medium
+wb-configs (3.16.0) stable; urgency=medium
 
   * Udev: add specific tag to WB-internal modems
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-configs (3.16.0) stable; urgency=medium
 
-  * Udev: add specific tag to WB-internal modems
+  * Udev: add specific tag ("wbc") to WB-internal modems
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 04 May 2023 13:36:12 +0300
 


### PR DESCRIPTION
решили привязать нашему модему специальный тег, чтобы потом дёргать модем по нему
предлагаю тег "wbc"

интересно, что udev имеет доступ к of_compatible и of_name из коробки

проверить можно mmcli -m wbc --set-primary-sim-slot=1