### PR TITLE
Feature/60432 web expand rootfs

### DIFF
--- a/configs/usr/lib/cgi-bin/fwupdate_upload.py
+++ b/configs/usr/lib/cgi-bin/fwupdate_upload.py
@@ -52,11 +52,8 @@ if "expand_rootfs" in form.keys() and str(form.getvalue("expand_rootfs")) == 'tr
     os.makedirs(RW_DIR, exist_ok=True)
     # create flags file
     flags_file = os.path.join(RW_DIR, 'install_update.web.flags')
-    sys.stdout.write("X-Flags-File: " + flags_file + "\r\n")
     with open(flags_file, "w") as flags_file_h:
         flags_file_h.write('--force-repartition')
-    with open(flags_file, "r") as flags_file_h:
-        sys.stdout.write("X-Flag-File-Contents: " + flags_file_h.read() + "\r\n")
 
 # handle upload
 uploading_file = form["file"]

--- a/configs/usr/lib/cgi-bin/fwupdate_upload.py
+++ b/configs/usr/lib/cgi-bin/fwupdate_upload.py
@@ -46,15 +46,16 @@ if "file" not in form.keys():  # get("file") does not work (due to FieldStorage 
     _error("Incorrect request")
 
 # handle "expand_rootfs" POST argument
-flags_file = os.path.join(RW_DIR, 'install_update.web.flags')
 if "expand_rootfs" in form.keys() and str(form.getvalue("expand_rootfs")) == 'true':
+    # we need to update-with-reboot in order to expand rootfs, so we're changing output directory to .wb_update
+    RW_DIR = "/mnt/data/.wb-update/"
+    # create flags file
+    flags_file = os.path.join(RW_DIR, 'install_update.web.flags')
     sys.stdout.write("X-Flags-File: " + flags_file + "\r\n")
     with open(flags_file, "w") as flags_file_h:
         flags_file_h.write('--force-repartition')
     with open(flags_file, "r") as flags_file_h:
         sys.stdout.write("X-Flag-File-Contents: " + flags_file_h.read() + "\r\n")
-elif os.path.exists(flags_file):
-    os.unlink(flags_file)
 
 # handle upload
 uploading_file = form["file"]

--- a/configs/usr/lib/cgi-bin/fwupdate_upload.py
+++ b/configs/usr/lib/cgi-bin/fwupdate_upload.py
@@ -49,6 +49,7 @@ if "file" not in form.keys():  # get("file") does not work (due to FieldStorage 
 if "expand_rootfs" in form.keys() and str(form.getvalue("expand_rootfs")) == 'true':
     # we need to update-with-reboot in order to expand rootfs, so we're changing output directory to .wb_update
     RW_DIR = "/mnt/data/.wb-update/"
+    os.makedirs(RW_DIR, exist_ok=True)
     # create flags file
     flags_file = os.path.join(RW_DIR, 'install_update.web.flags')
     sys.stdout.write("X-Flags-File: " + flags_file + "\r\n")

--- a/configs/usr/lib/cgi-bin/fwupdate_upload.py
+++ b/configs/usr/lib/cgi-bin/fwupdate_upload.py
@@ -45,6 +45,18 @@ form = DiskFieldStorage(encoding="utf-8")
 if "file" not in form.keys():  # get("file") does not work (due to FieldStorage internals)
     _error("Incorrect request")
 
+# handle "expand_rootfs" POST argument
+flags_file = os.path.join(RW_DIR, 'install_update.web.flags')
+if "expand_rootfs" in form.keys() and str(form.getvalue("expand_rootfs")) == 'true':
+    sys.stdout.write("X-Flags-File: " + flags_file + "\r\n")
+    with open(flags_file, "w") as flags_file_h:
+        flags_file_h.write('--force-repartition')
+    with open(flags_file, "r") as flags_file_h:
+        sys.stdout.write("X-Flag-File-Contents: " + flags_file_h.read() + "\r\n")
+elif os.path.exists(flags_file):
+    os.unlink(flags_file)
+
+# handle upload
 uploading_file = form["file"]
 if hasattr(uploading_file, "filename") and hasattr(uploading_file, "file"):
     fname = uploading_file.filename or "fwupdate"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.17.0) stable; urgency=medium
+
+  * Add web-update feature to expand rootfs from web UI
+
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Fri, 26 May 2023 15:45 +0600
+
 wb-configs (3.16.0) stable; urgency=medium
 
   * Udev: add ModemManager specific tag ("wbc") to WB-internal modems. mmcli -m wbc could be used to manage the modem

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/contactless/wb-configs
 
 Package: wb-configs
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 4.1.0), inotify-tools, mosquitto (>= 1.4.7-1), watchdog (>= 5.15),
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 4.11.0), inotify-tools, mosquitto (>= 1.4.7-1), watchdog (>= 5.15),
          linux-image-wb2 | linux-image-wb6 (>= 5.10.35-wb127~~) | linux-image-wb7 (>= 5.10.35-wb127~~), fcgiwrap, wb-update-manager, sudo, pigz
 Pre-Depends: wb-update-manager
 Provides: ${diverted-files}, mqtt-wss


### PR DESCRIPTION
Правка добавляет поддержку передаваемого от http-клиента флага "expand_rootfs" и передачу его дальше в специальный flags-файл.