### PR TITLE
mosquitto: fix pid_file path

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.18.3) stable; urgency=medium
+
+  * mosquitto: fix pid_file path after upgrade of mosquitto from 1.x to 2.x
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 11 Jul 2023 13:24:00 +0400
+
 wb-configs (3.18.2) stable; urgency=medium
 
   * Add /bin/ path to tar, mount and umount

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -253,8 +253,16 @@ add_mmc_mount_options
 mosquitto_fixes()
 {
     MOSQUITTO_CONF="/etc/mosquitto/mosquitto.conf"
+    local restart_required=0
     if grep -q "log_dest file /var/log/mosquitto/mosquitto.log" $MOSQUITTO_CONF; then
         sed -i 's#log_dest file /var/log/mosquitto/mosquitto.log#log_dest syslog#' $MOSQUITTO_CONF
+        restart_required=1
+    fi
+    if grep -q "pid_file /var/run/mosquitto.pid" $MOSQUITTO_CONF; then
+        sed -i 's#pid_file /var/run/mosquitto.pid#pid_file /run/mosquitto/mosquitto.pid#' $MOSQUITTO_CONF
+        restart_required=1
+    fi
+    if [ $restart_required -eq 1 ]; then
         deb-systemd-invoke restart mosquitto
     fi
 }


### PR DESCRIPTION
Если до апгрейда на bullseye `/etc/mosquitto/mosquitto.conf` изменялся вручную, то в процессе апгрейда конфиг останется прежним. Сейчас это ожидаемое поведение (`apt-get -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold --yes ...`). Учитывая что единственное изменение в mosquitto.conf при апгрейде на bullseye это pid_file, можно хотя бы для части пользователей (тех кто редактировал mosquitto.conf, но не менял pid_file) сделать апгрейд более гладким. Иначе придется в процессе апгрейда спрашивать пользователя, что делать с таким конфигом.