### PR TITLE
Ignore routes to down links

### DIFF
--- a/configs/etc/sysctl.conf.wb
+++ b/configs/etc/sysctl.conf.wb
@@ -1,2 +1,1 @@
 vm.swappiness = 1
-net.ipv4.conf.default.ignore_routes_with_linkdown = 1

--- a/configs/etc/sysctl.conf.wb
+++ b/configs/etc/sysctl.conf.wb
@@ -1,1 +1,2 @@
 vm.swappiness = 1
+net.ipv4.conf.default.ignore_routes_with_linkdown = 1

--- a/configs/etc/sysctl.d/99-ignore-linkdown.conf
+++ b/configs/etc/sysctl.d/99-ignore-linkdown.conf
@@ -1,0 +1,1 @@
+net.ipv4.conf.default.ignore_routes_with_linkdown = 1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.18.3) stable; urgency=medium
+
+  * Ignore routes to down links
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 18 Jul 2023 11:39:29 +0500
+
 wb-configs (3.18.2) stable; urgency=medium
 
   * Add /bin/ path to tar, mount and umount


### PR DESCRIPTION
NetworkManager can bring up connections on down links, if the connection has static ip. Depending on metric, the connection can became preferred default route, so all packets go to down link, and connectivity is broken. Add option to ignore routes to down links

![image](https://github.com/wirenboard/wb-configs/assets/86825564/f1763aa1-c48f-4f06-ae74-89343791753c)
