### PR TITLE
udev: add specific tag to WB-internal modems (#118)

### DIFF
--- a/configs/etc/udev/rules.d/99-wb-modem.rules
+++ b/configs/etc/udev/rules.d/99-wb-modem.rules
@@ -3,15 +3,23 @@ SUBSYSTEMS=="usb", GOTO="wb_usb_modem_types"
 
 LABEL="wb_usb_modem_types"
 
+# WB-internal modems have simselect gpio and specific tag (mmcli -m tag)
+ENV{OF_COMPATIBLE_0}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+ENV{OF_COMPATIBLE_1}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+ENV{OF_COMPATIBLE_2}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+ENV{OF_COMPATIBLE_3}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+ENV{OF_COMPATIBLE_4}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+ENV{OF_COMPATIBLE_5}=="wirenboard,wbc-usb", ENV{ID_MM_PHYSDEV_UID}="wbc", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT"
+
 # SIMCOM SIM800C-DS: ignore
 ATTRS{idVendor}=="0e8d", ATTRS{idProduct}=="0003", ENV{ID_MM_DEVICE_IGNORE}="1"
 # SIMCOM SIM5300E: ignore
 ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="0020", ENV{ID_MM_DEVICE_IGNORE}="1"
 # SIMCOM SIM7000E: ignore
 ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9001", ENV{ID_MM_DEVICE_IGNORE}="1"
-# SIMCOM A7600E-H: SIM switch and mark RNDIS unmanaged for NetworkManager
-ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{ID_MM_SIM_SWITCH_GPIO_LABEL}="SIM_SELECT", ENV{NM_UNMANAGED}="1"
-# QUECTEL EC200T-EU: SIM switch and mark RNDIS unmanaged for NetworkManager
+# SIMCOM A7600E-H: mark RNDIS unmanaged for NetworkManager
+ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{NM_UNMANAGED}="1"
+# QUECTEL EC200T-EU: ignore
 ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="6026", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 LABEL="wb_modem_end"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.13.1-wb106) stable; urgency=medium
+
+  * Udev: add ModemManager specific tag ("wbc") to WB-internal modems. mmcli -m wbc could be used to manage the modem
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 18 Jul 2023 16:21:17 +0300
+
 wb-configs (3.13.1-wb105) stable; urgency=medium
 
   * Fix .postinst exit status


### PR DESCRIPTION
* udev: add specific tag to WB-internal modems

* bump version

* rework udev rule to add simselect_gpio only to compatible modem

* rework simselect gpio

* slight comments changes

* Update debian/changelog



---------

В вики написали, что с 2304 можно делать mmcli -m wbc, а бекпортировать - забыли