### PR TITLE
mosquitto: move /etc/mosquitto/conf.d to /mnt/data

### DIFF
--- a/configs/etc/wb-configs.d/01wb-configs
+++ b/configs/etc/wb-configs.d/01wb-configs
@@ -36,9 +36,7 @@ wb_move_nosavefiles /var/www/uploads/ /uploads  # here will be firmware updates
 wb_move /etc/lirc/lircd.conf.d/
 wb_move /etc/nginx/passwd
 wb_move /etc/nginx/sites-enabled/
-wb_move /etc/mosquitto/conf.d/00default_listener.conf
-wb_move /etc/mosquitto/conf.d/10listeners.conf
-wb_move /etc/mosquitto/conf.d/20bridges.conf
+wb_move /etc/mosquitto/conf.d/
 wb_move /etc/mosquitto/passwd/
 wb_move /etc/mosquitto/acl/
 wb_move_watch /etc/localtime

--- a/configs/usr/bin/wb-configs-early
+++ b/configs/usr/bin/wb-configs-early
@@ -42,6 +42,7 @@ wb_fix_data_file()
         fi
     else
         if [[ ! -L "${src}" ]]; then
+            echo "$dst already exists, but $src is not a symlink"
             cp -aH "${src}" `dirname "${dst}"` || true
         fi
     fi

--- a/configs/usr/bin/wb-configs-early
+++ b/configs/usr/bin/wb-configs-early
@@ -40,6 +40,10 @@ wb_fix_data_file()
             echo "$src: saving backup to ${src}.default"
             cp -aH "$f" "${src}.default"
         fi
+    else
+        if [[ ! -L "${src}" ]]; then
+            cp -aH "${src}" `dirname "${dst}"` || true
+        fi
     fi
 }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.18.5) stable; urgency=medium
+
+  * mosquitto: move /etc/mosquitto/conf.d to /mnt/data
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 17 Jul 2023 17:13:00 +0400
+
 wb-configs (3.18.4) stable; urgency=medium
 
   * Fix .postinst exit status


### PR DESCRIPTION
### How to test
Before:
```sh
$ ls -l /etc/mosquitto/conf.d
total 0
lrwxrwxrwx 1 root root 54 Jul 20 10:06 00default_listener.conf -> /mnt/data/etc/mosquitto/conf.d/00default_listener.conf
-rw-r--r-- 1 root root  0 Jul 19 18:45 00default_listener.conf.default
lrwxrwxrwx 1 root root 47 Jul 20 10:06 10listeners.conf -> /mnt/data/etc/mosquitto/conf.d/10listeners.conf
lrwxrwxrwx 1 root root 45 Jul 20 10:07 20bridges.conf -> /mnt/data/etc/mosquitto/conf.d/20bridges.conf
-rw-r--r-- 1 root root  0 Jul 19 18:46 30test.conf
$ ls -l /mnt/data/etc/mosquitto/conf.d
total 12
-rw-r--r-- 1 root root 367 Apr 13 16:16 00default_listener.conf
-rw-r--r-- 1 root root 854 Apr 13 16:16 10listeners.conf
-rw-r--r-- 1 root root 163 Jul 12 17:35 20bridges.conf
```
Call `wb_move /etc/mosquitto/conf.d/`:
```sh
$ /usr/bin/wb-configs-early start
Checking symlinks to /mnt/data
cp: '/etc/mosquitto/conf.d/00default_listener.conf' and '/mnt/data/etc/mosquitto/conf.d/00default_listener.conf' are the same file
cp: '/etc/mosquitto/conf.d/10listeners.conf' and '/mnt/data/etc/mosquitto/conf.d/10listeners.conf' are the same file
cp: '/etc/mosquitto/conf.d/20bridges.conf' and '/mnt/data/etc/mosquitto/conf.d/20bridges.conf' are the same file
/etc/mosquitto/conf.d: symlinking to /mnt/data/etc/mosquitto/conf.d
Setting ownership www-data to /mnt/data/uploads
```

After:
```sh
$ ls -l /etc/mosquitto/conf.d
lrwxrwxrwx 1 root root 30 Jul 20 10:08 /etc/mosquitto/conf.d -> /mnt/data/etc/mosquitto/conf.d/
$ ls -l /mnt/data/etc/mosquitto/conf.d
total 12
-rw-r--r-- 1 root root 367 Apr 13 16:16 00default_listener.conf
-rw-r--r-- 1 root root   0 Jul 19 18:45 00default_listener.conf.default
-rw-r--r-- 1 root root 854 Apr 13 16:16 10listeners.conf
-rw-r--r-- 1 root root 163 Jul 12 17:35 20bridges.conf
-rw-r--r-- 1 root root   0 Jul 19 18:46 30test.conf
```

Call `wb_move /etc/mosquitto/conf.d/` one more time:
```sh
$ /usr/bin/wb-configs-early start
Checking symlinks to /mnt/data
Setting ownership www-data to /mnt/data/uploads
```