### PR TITLE
Fix deb/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.18.5) stable; urgency=medium
+
+  * Fix deb/changelog
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 25 Jul 2023 20:02:00 +0400
+
 wb-configs (3.18.4) stable; urgency=medium
 
   * Fix .postinst exit status
@@ -26,7 +32,7 @@ wb-configs (3.18.0) stable; urgency=medium
 
   * Add web-update option to expand rootfs from web UI
 
- -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Fri, 26 May 2023 15:45 +0600
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Fri, 26 May 2023 15:45:00 +0600
 
 wb-configs (3.17.0) stable; urgency=medium
 
@@ -76,7 +82,7 @@ wb-configs (3.14.0) stable; urgency=medium
 
   * Add feature to download rootfs archive via web UI
 
- -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Tue, 14 Mar 2023 21:14 +0600
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Tue, 14 Mar 2023 21:14:00 +0600
 
 wb-configs (3.13.1) stable; urgency=medium
 
@@ -186,7 +192,7 @@ wb-configs (3.6.0) stable; urgency=medium
 
   * Add motd banner with system information
 
- -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 16 Dec 2022 16:532:00 +0400
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 16 Dec 2022 16:53:00 +0400
 
 wb-configs (3.5.2) stable; urgency=medium
 
@@ -546,7 +552,7 @@ wb-configs (1.76.2) stable; urgency=critical
 
  -- Nikita Maslov <n.maslov@contactless.ru>  Thu, 28 Jun 2018 12:08:07 +0300
 
-wb-configs (1.76.1) stable; urgent=medium
+wb-configs (1.76.1) stable; urgency=medium
 
   * add logrotate conf for /var/log/messages
 
@@ -558,31 +564,31 @@ wb-configs (1.76) stable; urgency=medium
 
  -- Evgeny Boger <boger@contactless.ru>  Fri, 01 Jun 2018 22:29:36 +0300
 
-wb-configs (1.75.4) stable; urgent=medium
+wb-configs (1.75.4) stable; urgency=medium
 
   * change debian repo url to stable
 
  -- Evgeny Boger <boger@contactless.ru>  Wed, 28 Mar 2018 15:03:22 +0300
 
-wb-configs (1.75.3) stable; urgent=medium
+wb-configs (1.75.3) stable; urgency=medium
 
   * wb-watch-configs moved
 
  -- Attila Door <a.door@contactless.ru>  Wed, 28 Mar 2018 15:03:22 +0300
 
-wb-configs (1.75.2) stable; urgent=medium
+wb-configs (1.75.2) stable; urgency=medium
 
   * add ssh config to displace list
 
  -- Attila Door <a.door@contactless.ru>  Wed, 21 Mar 2018 15:03:22 +0300
 
-wb-configs (1.75.1) stable; urgent=medium
+wb-configs (1.75.1) stable; urgency=medium
 
   * add networking service systemd config to stretch configs
 
  -- Attila Door <a.door@contactless.ru>  Wed, 21 Mar 2018 15:03:22 +0300
 
-wb-configs (1.75.0) stable; urgent=medium
+wb-configs (1.75.0) stable; urgency=medium
 
   * add wb-configs-stretch and wheezy
 


### PR DESCRIPTION
Changelog генератор ловит артефакты:

<img width="1470" alt="Näyttökuva 2023-7-25 kello 21 03 37" src="https://github.com/wirenboard/wb-configs/assets/688044/16248158-70b3-4489-8c64-8df845a24aa0">

И lintian ругается:
```sh
W: wb-configs: syntax-error-in-debian-changelog line 189 "badly formatted trailer line"
W: wb-configs: syntax-error-in-debian-changelog line 191 "found start of entry where expected more change data or trailer"
W: wb-configs: syntax-error-in-debian-changelog line 29 "badly formatted trailer line"
W: wb-configs: syntax-error-in-debian-changelog line 31 "found start of entry where expected more change data or trailer"
W: wb-configs: syntax-error-in-debian-changelog line 549 "unknown key-value key Urgent - copying to XS-Urgent"
W: wb-configs: syntax-error-in-debian-changelog line 561 "unknown key-value key Urgent - copying to XS-Urgent"
W: wb-configs: syntax-error-in-debian-changelog line 567 "unknown key-value key Urgent - copying to XS-Urgent"
W: wb-configs: syntax-error-in-debian-changelog line 573 "unknown key-value key Urgent - copying to XS-Urgent"
W: wb-configs: syntax-error-in-debian-changelog line 579 "unknown key-value key Urgent - copying to XS-Urgent"
W: wb-configs: syntax-error-in-debian-changelog line 585 "unknown key-value key Urgent - copying to XS-Urgent"
W: wb-configs: syntax-error-in-debian-changelog line 79 "badly formatted trailer line"
W: wb-configs: syntax-error-in-debian-changelog line 81 "found start of entry where expected more change data or trailer"
```