### PR TITLE
Ignore routes to down links

### DIFF
--- a/configs/etc/sysctl.d/99-ignore-linkdown.conf
+++ b/configs/etc/sysctl.d/99-ignore-linkdown.conf
@@ -1,0 +1,1 @@
+net.ipv4.conf.default.ignore_routes_with_linkdown = 1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.18.7) stable; urgency=medium
+
+  * Ignore routes to down links
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 28 Jul 2023 08:50:04 +0500
+
 wb-configs (3.18.6) stable; urgency=medium
 
   * mosquitto: move /etc/mosquitto/conf.d to /mnt/data
@@ -15,12 +21,6 @@ wb-configs (3.18.4) stable; urgency=medium
   * Fix .postinst exit status
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 17 Jul 2023 17:12:00 +0400
-
-wb-configs (3.18.3) stable; urgency=medium
-
-  * mosquitto: fix pid_file path after upgrade of mosquitto from 1.x to 2.x
-
- -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 11 Jul 2023 13:24:00 +0400
 
 wb-configs (3.18.2) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Maintainer: Evgeny Boger <boger@contactless.ru>
 Build-Depends: debhelper (>= 10), config-package-dev (>= 5.0)
 Standards-Version: 3.9.4
-Homepage: https://github.com/contactless/wb-configs
+Homepage: https://github.com/wirenboard/wb-configs
 
 Package: wb-configs
 Architecture: all


### PR DESCRIPTION
NetworkManager can bring up connections on down links, if the connection has static ip. Depending on metric, the connection can became preferred default route, so all packets go to down link, and connectivity is broken. Add option to ignore routes to down links

Rebase of https://github.com/wirenboard/wb-configs/pull/125