### PR TITLE
Restore /etc/mosquitto/conf.d folder in .postrm

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.18.10) stable; urgency=medium
+
+  * Restore /etc/mosquitto/conf.d folder in .postrm
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 09 Aug 2023 21:30:00 +0400
+
 wb-configs (3.18.9) stable; urgency=medium
 
   * Get wb-ap SSID prefix from env variable

--- a/debian/wb-configs.postrm
+++ b/debian/wb-configs.postrm
@@ -37,3 +37,20 @@ for file in "${mosquitto_apps[@]}"; do
         dpkg-divert --package wb-configs --rename --remove "/usr/bin/${file}"
     fi
 done
+
+# restore original mosquitto conf.d directory to support switching between testing and stable (wb-2307)
+# (it would be better to fix wb_move function in wb-configs-early, but it requires changes in stable release)
+# can be removed with next stable release
+if [ -L /etc/mosquitto/conf.d ] && [ "$(readlink /etc/mosquitto/conf.d)" = "/mnt/data/etc/mosquitto/conf.d" ]; then
+    rm /etc/mosquitto/conf.d
+    rsync -av --exclude=00default_listener.conf --exclude=10listeners.conf --exclude=20bridges.conf /mnt/data/etc/mosquitto/conf.d /etc/mosquitto
+    if [ -f /mnt/data/etc/mosquitto/conf.d/00default_listener.conf ]; then
+        ln -Tfs /mnt/data/etc/mosquitto/conf.d/00default_listener.conf /etc/mosquitto/conf.d/00default_listener.conf
+    fi
+    if [ -f /mnt/data/etc/mosquitto/conf.d/10listeners.conf ]; then
+        ln -Tfs /mnt/data/etc/mosquitto/conf.d/10listeners.conf /etc/mosquitto/conf.d/10listeners.conf
+    fi
+    if [ -f /mnt/data/etc/mosquitto/conf.d/20bridges.conf ]; then
+        ln -Tfs /mnt/data/etc/mosquitto/conf.d/20bridges.conf /etc/mosquitto/conf.d/20bridges.conf
+    fi
+fi


### PR DESCRIPTION
Test instructions:
```sh
$ wb-release -t testing
$ /usr/bin/wb-configs-early start
$ ls -la /etc/mosquitto/conf.d
lrwxrwxrwx 1 root root 30 Aug 10 19:30 /etc/mosquitto/conf.d -> /mnt/data/etc/mosquitto/conf.d/
$ ls -la /mnt/data/etc/mosquitto/conf.d
total 56
drwxr-xr-x 2 root root 4096 Aug 10 19:29 ./
drwxr-xr-x 5 root root 4096 Aug  8 09:57 ../
-rw-r--r-- 1 root root  367 Jul 25 16:02 00default_listener.conf
-rw-r--r-- 1 root root  367 Jul 25 16:02 00default_listener.conf.default
-rw-r--r-- 1 root root  367 Aug  4 13:15 00default_listener.conf.dpkg-new
-rw-r--r-- 1 root root  854 Jul 25 16:02 10listeners.conf
-rw-r--r-- 1 root root  854 Jul 25 16:02 10listeners.conf.default
-rw-r--r-- 1 root root  854 Aug  4 13:15 10listeners.conf.dpkg-new
-rw-r--r-- 1 root root  121 Jul 25 16:02 20bridges.conf
-rw-r--r-- 1 root root  121 Jul 25 16:02 20bridges.conf.default
-rw-r--r-- 1 root root  121 Aug  4 13:15 20bridges.conf.dpkg-new
-rw-r--r-- 1 root root  344 Jul 25 16:02 21bridge.conf.example
-rw-r--r-- 1 root root  130 Aug 10 19:29 30limits.conf
-rw-r--r-- 1 root root  142 Jun  9  2021 README
$ wb-release -t stable
$ ls -la /etc/mosquitto/conf.d
total 44
drwxr-xr-x 2 root root 4096 Aug 10 19:40 ./
drwxr-xr-x 7 root root 4096 Aug 10 19:40 ../
lrwxrwxrwx 1 root root   54 Aug 10 19:40 00default_listener.conf -> /mnt/data/etc/mosquitto/conf.d/00default_listener.conf
-rw-r--r-- 1 root root  367 Jul 25 16:02 00default_listener.conf.default
-rw-r--r-- 1 root root  367 Aug  4 13:15 00default_listener.conf.dpkg-new
lrwxrwxrwx 1 root root   47 Aug 10 19:40 10listeners.conf -> /mnt/data/etc/mosquitto/conf.d/10listeners.conf
-rw-r--r-- 1 root root  854 Jul 25 16:02 10listeners.conf.default
-rw-r--r-- 1 root root  854 Aug  4 13:15 10listeners.conf.dpkg-new
lrwxrwxrwx 1 root root   45 Aug 10 19:40 20bridges.conf -> /mnt/data/etc/mosquitto/conf.d/20bridges.conf
-rw-r--r-- 1 root root  121 Jul 25 16:02 20bridges.conf.default
-rw-r--r-- 1 root root  121 Aug  4 13:15 20bridges.conf.dpkg-new
-rw-r--r-- 1 root root  344 Jul 25 16:02 21bridge.conf.example
-rw-r--r-- 1 root root  130 Aug 10 19:29 30limits.conf
-rw-r--r-- 1 root root  142 Jun  9  2021 README
$ ls -la /mnt/data/etc/mosquitto/conf.d
total 56
drwxr-xr-x 2 root root 4096 Aug 10 19:29 ./
drwxr-xr-x 5 root root 4096 Aug  8 09:57 ../
-rw-r--r-- 1 root root  367 Jul 25 16:02 00default_listener.conf
-rw-r--r-- 1 root root  367 Jul 25 16:02 00default_listener.conf.default
-rw-r--r-- 1 root root  367 Aug  4 13:15 00default_listener.conf.dpkg-new
-rw-r--r-- 1 root root  854 Jul 25 16:02 10listeners.conf
-rw-r--r-- 1 root root  854 Jul 25 16:02 10listeners.conf.default
-rw-r--r-- 1 root root  854 Aug  4 13:15 10listeners.conf.dpkg-new
-rw-r--r-- 1 root root  121 Jul 25 16:02 20bridges.conf
-rw-r--r-- 1 root root  121 Jul 25 16:02 20bridges.conf.default
-rw-r--r-- 1 root root  121 Aug  4 13:15 20bridges.conf.dpkg-new
-rw-r--r-- 1 root root  344 Jul 25 16:02 21bridge.conf.example
-rw-r--r-- 1 root root  130 Aug 10 19:29 30limits.conf
-rw-r--r-- 1 root root  142 Jun  9  2021 README
```