### PR TITLE
Don't source wb_env.sh for wb-ts terminal

### DIFF
--- a/configs/root/.bashrc.wb
+++ b/configs/root/.bashrc.wb
@@ -1,3 +1,2 @@
 export PYTHONPATH=$PYTHONPATH:/opt/quick2wire-python-api-master/
-. /etc/wb_env.sh
-
+[[ "$LC_TERMINAL" = "wb-ts" ]] || . /etc/wb_env.sh

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.18.11) stable; urgency=medium
+
+  * Don't source wb_env.sh for wb-ts terminal
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 15 Aug 2023 18:23:00 +0400
+
 wb-configs (3.18.10) stable; urgency=medium
 
   * Restore /etc/mosquitto/conf.d folder in .postrm


### PR DESCRIPTION
Для тестирования нам надо иметь возможность открывать ssh сессию без инициализации wb_env.sh, для этого предлагается проверять передаваемый `LC_TERMINAL` как отличительный признак тестовой сессии.