### PR TITLE
don't allow serial terminal to change baudrate to 9600

### DIFF
--- a/configs/etc/systemd/system/serial-getty@ttyS0.service.d/override.conf
+++ b/configs/etc/systemd/system/serial-getty@ttyS0.service.d/override.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty -o '-p -- \\u' --keep-baud %I $TERM
+ExecStart=-/sbin/agetty -o '-p -- \\u' 115200 %I $TERM

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-configs (3.18.12) UNRELEASED; urgency=medium
+wb-configs (3.18.12) stable; urgency=medium
 
   * don't allow serial terminal to change baudrate to 9600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.18.12) UNRELEASED; urgency=medium
+
+  * don't allow serial terminal to change baudrate to 9600
+
+ -- Evgeny Boger <boger@wirenboard.com>  Thu, 21 Sep 2023 17:07:51 +0300
+
 wb-configs (3.18.11) stable; urgency=medium
 
   * use Wiren Board debian mirror instead of Debian CDN by default


### PR DESCRIPTION
this time for real, I promise.

So agetty will switch between list of baudrates when getting BREAK condition. This behaviour causes all sorts of problems because a) it can never go back to higher baudrate
b) BREAK condition can also be caused by noise/power-on and reset glitches and other stuff besides user typing at lower baudrate

We tried to fix it by removing the list of baudrate to iterate. But unfortunately apparently agetty iterprets ''--keep-baud' as list of current baudrate (115200, set by u-boot) and 9600. It's somehow suggested by the man agetty:

   "and if unsuccessful then default to '9600'."

So tihs time we set baudrate to 115200, period.
We verified that it inteed prevents agetty from switching to 9600.