### PR TITLE
Support RTL8733BU

### DIFF
--- a/configs/etc/modprobe.d/8733bu.conf
+++ b/configs/etc/modprobe.d/8733bu.conf
@@ -1,0 +1,1 @@
+options 8733bu rtw_drv_log_level=3

--- a/configs/lib/systemd/network/50-wb-wifi-usb.link
+++ b/configs/lib/systemd/network/50-wb-wifi-usb.link
@@ -1,5 +1,5 @@
 [Match]
-Driver=rtl8723bu
+Driver=rtl8723bu rtl8733bu
 
 [Link]
 NamePolicy=kernel

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.19.0) stable; urgency=medium
+
+  * Support RTL8733BU
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 28 Sep 2023 10:49:38 +0500
+
 wb-configs (3.18.12) stable; urgency=medium
 
   * don't allow serial terminal to change baudrate to 9600


### PR DESCRIPTION
Сделал наименование интерфейсов как в rt8723 и убрал ненужные сообщения из dmesg.