### PR TITLE
Fix configs overwriting after update using fit

### DIFF
--- a/configs/usr/bin/wb-configs-early
+++ b/configs/usr/bin/wb-configs-early
@@ -43,7 +43,7 @@ wb_fix_data_file()
     else
         if [[ -d "${src}" ]] && [[ ! -L "${src}" ]]; then
             echo "$dst already exists, but $src is not a symlink, copy missing files"
-            cp -anH "${src}" "${dst}" || true
+            cp -anH "${src}" `dirname "${dst}"` || true
         fi
     fi
 }

--- a/configs/usr/bin/wb-configs-early
+++ b/configs/usr/bin/wb-configs-early
@@ -41,9 +41,9 @@ wb_fix_data_file()
             cp -aH "$f" "${src}.default"
         fi
     else
-        if [[ ! -L "${src}" ]]; then
-            echo "$dst already exists, but $src is not a symlink"
-            cp -aH "${src}" `dirname "${dst}"` || true
+        if [[ -d "${src}" ]] && [[ ! -L "${src}" ]]; then
+            echo "$dst already exists, but $src is not a symlink, copy missing files"
+            cp -anH "${src}" "${dst}" || true
         fi
     fi
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.19.3) stable; urgency=medium
+
+  * Fix configs overwriting after update using fit
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 17 Nov 2023 10:17:38 +0500
+
 wb-configs (3.19.2) stable; urgency=medium
 
   * fix_mosquitto.sh: don't move config if .keep file exists


### PR DESCRIPTION
При обновлении фитом старая версия затирала все конфиги, т.к. симлинков не было.
Насколько я понимаю, вся эта машинерия нужна только в случае обновления со старой схемы (раньше были симлинки на конкретные файлы конфига москиты) на бэкап всего каталога.
Сделал так, чтобы всё работало только для каталогов и копировало только недостающие файлы.