### PR TITLE
Increase mosquitto max_inflight_messages limit

### DIFF
--- a/configs/etc/mosquitto/conf.d/30limits.conf
+++ b/configs/etc/mosquitto/conf.d/30limits.conf
@@ -3,3 +3,4 @@
 
 max_queued_messages 0
 memory_limit 100000000
+max_inflight_messages 1000

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.21.2) stable; urgency=medium
+
+  * 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 23 Jan 2024 14:30:57 +0500
+
 wb-configs (3.21.1) stable; urgency=medium
 
   * fix default Wi-Fi access point configuration with RTL8733BU

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-configs (3.21.2) stable; urgency=medium
 
-  * 
+  * Increase mosquitto max_inflight_messages limit
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 23 Jan 2024 14:30:57 +0500
 


### PR DESCRIPTION
Mosquitto drops websocket connection if max_inflight_messages limit is exceeded. So set relatively big value

Пример того, как воспроизвести [тут](https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/68472/)