### PR TITLE
fwupdate_upload: handle update from cloud

### DIFF
--- a/configs/usr/lib/cgi-bin/fwupdate_upload.py
+++ b/configs/usr/lib/cgi-bin/fwupdate_upload.py
@@ -64,7 +64,8 @@ def main():
     # handle extra POST arguments
     do_expand_rootfs = "expand_rootfs" in form.keys() and str(form.getvalue("expand_rootfs")) == 'true'
     do_factory_reset = "factory_reset" in form.keys() and str(form.getvalue("factory_reset")) == 'true'
-    if do_factory_reset or do_expand_rootfs:
+    is_from_cloud = "from_cloud" in form.keys() and str(form.getvalue("from_cloud")) == 'true'
+    if do_factory_reset or do_expand_rootfs or is_from_cloud:
         # we need to update-with-reboot in order to expand rootfs, so we're changing output directory to .wb_update
         RW_DIR = "/mnt/data/.wb-update/"
         os.makedirs(RW_DIR, exist_ok=True)
@@ -75,6 +76,8 @@ def main():
                 flags_file_h.write('--factoryreset ')
             if do_expand_rootfs:
                 flags_file_h.write('--force-repartition ')
+            if is_from_cloud:
+                flags_file_h.write('--from-cloud ')
 
     # handle upload
     uploading_file = form["file"]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.22.2) stable; urgency=medium
+
+  * fwupdate_upload: handle update from cloud ("from_cloud" flag)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 25 Apr 2024 18:01:22 +0300
+
 wb-configs (3.22.1) stable; urgency=medium
 
   * remove openssl config with atecc engine description


### PR DESCRIPTION
Запрет прошивки контроллера из облака fit-ом без предустановленного wb-cloud-agent

связанных PR-ов - куча => проще всего потыкать:
обновиться из тестинг-сета http://deb.wirenboard.com/all@experimental.update-from-cloud:main

ребут
подключить к облаку
обновиться из облака stable-ом; увидеть ругательства
обновиться fit-ом [с поддержкой обновления из облака](https://jenkins.wirenboard.com/job/pipelines/job/build-image/6241/); не увидеть ругательства