### PR TITLE
Mosquitto: disable 18883 public websockets port

### DIFF
--- a/configs/etc/mosquitto/conf.d/10listeners.conf
+++ b/configs/etc/mosquitto/conf.d/10listeners.conf
@@ -25,7 +25,8 @@ password_file /etc/mosquitto/passwd/default.conf
 
 # Changed to localhost-only for security reasons for now
 
-listener 18883 localhost
+listener 18883 127.0.0.1
+socket_domain ipv4
 protocol websockets
 allow_anonymous true
 acl_file /etc/mosquitto/acl/default.conf

--- a/configs/etc/mosquitto/conf.d/10listeners.conf
+++ b/configs/etc/mosquitto/conf.d/10listeners.conf
@@ -25,8 +25,7 @@ password_file /etc/mosquitto/passwd/default.conf
 
 # Changed to localhost-only for security reasons for now
 
-listener 18883 127.0.0.1
-socket_domain ipv4
+listener 18883 lo
 protocol websockets
 allow_anonymous true
 acl_file /etc/mosquitto/acl/default.conf

--- a/configs/etc/mosquitto/conf.d/10listeners.conf
+++ b/configs/etc/mosquitto/conf.d/10listeners.conf
@@ -23,10 +23,10 @@ password_file /etc/mosquitto/passwd/default.conf
 #
 # It is recommended to add password authentication for security.
 
-# Disabled for security reasons for now
+# Changed to localhost-only for security reasons for now
 
-# listener 18883
-# protocol websockets
-# allow_anonymous true
-# acl_file /etc/mosquitto/acl/default.conf
-# password_file /etc/mosquitto/passwd/default.conf
+listener 18883 localhost
+protocol websockets
+allow_anonymous true
+acl_file /etc/mosquitto/acl/default.conf
+password_file /etc/mosquitto/passwd/default.conf

--- a/configs/etc/mosquitto/conf.d/10listeners.conf
+++ b/configs/etc/mosquitto/conf.d/10listeners.conf
@@ -22,8 +22,11 @@ password_file /etc/mosquitto/passwd/default.conf
 # old Wiren Board mosquitto configuration.
 #
 # It is recommended to add password authentication for security.
-listener 18883
-protocol websockets
-allow_anonymous true
-acl_file /etc/mosquitto/acl/default.conf
-password_file /etc/mosquitto/passwd/default.conf
+
+# Disabled for security reasons for now
+
+# listener 18883
+# protocol websockets
+# allow_anonymous true
+# acl_file /etc/mosquitto/acl/default.conf
+# password_file /etc/mosquitto/passwd/default.conf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-configs (3.26.5) stable; urgency=medium
 
-  * mosquitto: disabled websocket 18883 port for security reasons
+  * mosquitto: disabled public websocket 18883 port for security reasons
 
  -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Wed, 4 Jul 2024 11:50:00 +0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.26.5) stable; urgency=medium
+
+  * mosquitto: disabled websocket 18883 port for security reasons
+
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Wed, 4 Jul 2024 11:50:00 +0500
+
 wb-configs (3.26.4) stable; urgency=medium
 
   * nginx: enable gzip compression

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 4.11.0), inotify-
 Pre-Depends: wb-update-manager
 Provides: ${diverted-files}, mqtt-wss
 Conflicts: ${diverted-files}, mqtt-wss, wb-homa-adc (<< 1.9.2), wb-homa-gpio (<< 1.14), wb-mqtt-serial(<< 1.14.2), wb-rules(<< 1.5.1), busybox-syslogd (<< 9:1.0~dummy), nginx-common (<< 1.7.11)
-Breaks: wb-configs-stretch (<< 3.0.0)
+Breaks: wb-configs-stretch (<< 3.0.0), wb-mqtt-homeui (<< 2.92.0)
 Recommends: wb-essential, wb-suite, figlet
 Replaces: mqtt-wss, wb-configs-stretch (<< 3.0.0)
 Description: Default common config files for Wiren Board

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -273,7 +273,7 @@ mosquitto_fixes()
         restart_required=1
     fi
     if grep -q "^listener 18883$" $LISTENERS_CONF; then
-    	sed -i '/^listener 18883$/clistener 18883 127.0.0.1\nsocket_domain ipv4' $LISTENERS_CONF
+    	sed -i '/^listener 18883$/clistener 18883 lo' $LISTENERS_CONF
     	restart_required=1
     fi
     if [ $restart_required -eq 1 ]; then

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -258,6 +258,7 @@ add_mmc_mount_options
 mosquitto_fixes()
 {
     MOSQUITTO_CONF="/etc/mosquitto/mosquitto.conf"
+    LISTENERS_CONF='/etc/mosquitto/conf.d/10listeners.conf'
     local restart_required=0
     if grep -q "log_dest file /var/log/mosquitto/mosquitto.log" $MOSQUITTO_CONF; then
         sed -i 's#log_dest file /var/log/mosquitto/mosquitto.log#log_dest syslog#' $MOSQUITTO_CONF
@@ -270,6 +271,9 @@ mosquitto_fixes()
     if ! grep -q -F "include_dir /usr/share/wb-configs/mosquitto" $MOSQUITTO_CONF; then
         sed -i '\#include_dir /etc/mosquitto/conf.d#iinclude_dir /usr/share/wb-configs/mosquitto' $MOSQUITTO_CONF
         restart_required=1
+    fi
+    if grep -q "^listener 18883$" $LISTENERS_CONF; then
+    	sed -i '/^listener 18883$/clistener 18883 localhost' $LISTENERS_CONF
     fi
     if [ $restart_required -eq 1 ]; then
         if [ "$(deb-systemd-invoke is-enabled mosquitto)" != "masked" ]; then

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -273,7 +273,8 @@ mosquitto_fixes()
         restart_required=1
     fi
     if grep -q "^listener 18883$" $LISTENERS_CONF; then
-    	sed -i '/^listener 18883$/clistener 18883 localhost' $LISTENERS_CONF
+    	sed -i '/^listener 18883$/clistener 18883 127.0.0.1\nsocket_domain ipv4' $LISTENERS_CONF
+    	restart_required=1
     fi
     if [ $restart_required -eq 1 ]; then
         if [ "$(deb-systemd-invoke is-enabled mosquitto)" != "masked" ]; then


### PR DESCRIPTION
Тестинг-сет: `deb http://deb.wirenboard.com/all experimental.get-rid-of-18883 main`

Часть более крупной задачи -- отключение публичного порта 18883 и перевод homeui на работу с штатным nginx, который проксирует в локальный 18883 порт.

По этому PR критерий успеха -- чтобы порт 18883, который слушает mosquitto, сменился с :::18883 на 127.0.0.1:18883. 

При этом, если не ставить ответную версию homeui из тестинг-сета -- homeui сломается (отвалится от mqtt) до смены порта на 80-й в настройках webui. Если ставить тестинг-сет целиком -- всё должно работать штатно.