### PR TITLE
nginx: fix config warning

### DIFF
--- a/configs/etc/nginx/sites-available/default.wb
+++ b/configs/etc/nginx/sites-available/default.wb
@@ -29,7 +29,7 @@ server {
 	gzip_comp_level 6;
 	gzip_buffers 16 8k;
 	gzip_min_length 1200;
-	gzip_types text/plain text/html text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/font-woff image/svg+xml;
+	gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/font-woff image/svg+xml;
 
 	# Make site accessible from http://localhost/
 	server_name localhost;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.26.6) stable; urgency=medium
+
+  * nginx: fix config warning
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 12 Jul 2024 00:30:00 +0400
+
 wb-configs (3.26.5) stable; urgency=medium
 
   * mosquitto: disabled public websocket 18883 port for security reasons


### PR DESCRIPTION
Follow up https://github.com/wirenboard/wb-configs/pull/163
```sh
# journalctl -u nginx
...
Jul 11 17:54:31 wirenboard-A7PWH4NX nginx[1487]: nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/sites-enabled/default:32
Jul 11 17:54:33 wirenboard-A7PWH4NX nginx[1766]: nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/sites-enabled/default:32
...
# nginxx -t
nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/sites-enabled/default:32
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```
https://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_types:

> Enables gzipping of responses for the specified MIME types **in addition to “text/html”**. The special value “*” matches any MIME type (0.8.29). **Responses with the “text/html” type are always compressed.** 