### PR TITLE
try watchdog service script to check emmc health

### DIFF
--- a/configs/etc/watchdog.d/10wb-check-emmc
+++ b/configs/etc/watchdog.d/10wb-check-emmc
@@ -1,0 +1,1 @@
+../../usr/share/wb-configs/watchdog.d/10wb-check-emmc

--- a/configs/usr/share/wb-configs/watchdog.d/10wb-check-emmc
+++ b/configs/usr/share/wb-configs/watchdog.d/10wb-check-emmc
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Reset controller if eMMC failed (I/O errors)
+
+dd if=/bin/true of=/dev/null iflag=direct 2>/dev/null || exit 255

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.23.1-wb104+1) stable; urgency=medium
+
+  * try watchdog service script to check emmc health
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Mon, 15 Jul 2024 20:51:58 +0500
+
 wb-configs (3.23.1-wb104) stable; urgency=medium
 
   * add Node.js 20.x repository


### PR DESCRIPTION
Попробовал имитировать отвал emmc через fault injection в ядре, в итоге такой вариант оказался стабильно работающим. Экспериментально проверил, что после отвала emmc может произойти следующее:

1. скрипт и dd остались в кэше - тогда получается код возврата 255 и watchdog перезагружает контроллер сразу.
2. скрипт остался в кэше, но его выполнение вызывает i/o error - получается код возврата 126, тогда watchdog будет пытаться выполнить его ещё 30 секунд.
3. скрипт выпадает из кэша и попытка его вызвать вызывает i/o error - получается код возврата 5, watchdog продолжает пытаться его вызвать.
4. проходит 30 секунд попыток, watchdog пытается вызвать скрипт с аргументом `repair` и у него ничего не получается из-за i/o error - после этого контроллер перезагружается жёстко.

Скрипт поселил в /usr, чтобы он из-за своего размещения в /etc не стал conffile-ом и не было потом проблем с обновлением.