### PR TITLE
add watchdog service script to check emmc health

### DIFF
--- a/configs/etc/watchdog.d/10wb-check-emmc
+++ b/configs/etc/watchdog.d/10wb-check-emmc
@@ -1,0 +1,1 @@
+../../usr/share/wb-configs/watchdog.d/10wb-check-emmc

--- a/configs/usr/share/wb-configs/watchdog.d/10wb-check-emmc
+++ b/configs/usr/share/wb-configs/watchdog.d/10wb-check-emmc
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Reset controller if eMMC failed (I/O errors)
+
+dd if=/bin/true of=/dev/null iflag=direct 2>/dev/null || exit 255

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.27.0) stable; urgency=medium
+
+  * add watchdog service script to check emmc health
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Tue, 23 Jul 2024 12:05:05 +0500
+
 wb-configs (3.26.8) stable; urgency=medium
 
   * Use mosquitto unix socket for publishing open ports checking results


### PR DESCRIPTION
#168 нормально работает на wb8, не ожидаю проблем на wb7 и остальных контроллерах, пусть это живёт в тестинге.