### PR TITLE
nginx: check for broken symlinks in /etc/nginx/sites-enabled

### DIFF
--- a/configs/etc/wb-configs.d/04nginx-fix
+++ b/configs/etc/wb-configs.d/04nginx-fix
@@ -1,0 +1,1 @@
+/usr/lib/wb-configs/fix_nginx.sh

--- a/configs/usr/lib/wb-configs/fix_nginx.sh
+++ b/configs/usr/lib/wb-configs/fix_nginx.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SITES_ENABLED_DIR="/etc/nginx/sites-enabled"
+
+for config in "$SITES_ENABLED_DIR"/*; do
+    if [ -L "$config" ]; then
+        if [ ! -e "$config" ]; then
+            echo "Removing broken symlink: $config"
+            rm -f "$config"
+        fi
+    fi
+done

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.27.1) stable; urgency=medium
+
+  * nginx: check for broken symlinks in /etc/nginx/sites-enabled
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 05 Aug 2024 13:15:00 +0400
+
 wb-configs (3.27.0) stable; urgency=medium
 
   * add watchdog service script to check emmc health


### PR DESCRIPTION
Нужно в частности для удаления `/etc/nginx/sites-enabled/wb-cloud-agent`, который остается от wb-cloud-agent 1.0.0 при обновлении фитом.