### PR TITLE
disable persistence in mosquitto by default

### DIFF
--- a/configs/usr/share/wb-configs/mosquitto/000persistence.conf
+++ b/configs/usr/share/wb-configs/mosquitto/000persistence.conf
@@ -1,0 +1,4 @@
+# Disable persistence in mosquitto by default.
+# You can enable it back in /etc/mosquitto/conf.d/000persistence.conf
+
+persistence false

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.30.0) stable; urgency=medium
+
+  * disable persistence in mosquitto.conf by default
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Mon, 26 Aug 2024 10:52:35 +0500
+
 wb-configs (3.29.0) stable; urgency=medium
 
   * migrate udev rules installation to wb-prepare.d

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -244,6 +244,10 @@ mosquitto_fixes()
         sed -i '\#include_dir /etc/mosquitto/conf.d#iinclude_dir /usr/share/wb-configs/mosquitto' $MOSQUITTO_CONF
         restart_required=1
     fi
+    if grep -q "persistence .*" $MOSQUITTO_CONF; then
+        sed -i 's@persistence .*@# persistence is disabled by default. enable in /etc/mosquitto/conf.d/000persistence.conf@' $MOSQUITTO_CONF
+        restart_required=1
+    fi
     if grep -q "^listener 18883$" $LISTENERS_CONF; then
     	sed -i '/^listener 18883$/clistener 18883 lo' $LISTENERS_CONF
     	restart_required=1


### PR DESCRIPTION
Решили, что в этом тестинге будем выключать persistence в mosquitto по умолчанию. Обычно это доставляет больше проблем, чем приносит пользы.

Побочные эффекты нам ещё предстоит узнать, разумеется, потому сейчас это уходит в testing.