### PR TITLE
remove nodesource

### DIFF
--- a/configs/etc/apt/sources.list.d/nodesource.list
+++ b/configs/etc/apt/sources.list.d/nodesource.list
@@ -1,1 +1,0 @@
-deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x bullseye main

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.30.0) stable; urgency=medium
+
+  * remove nodesource
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 11 Sep 2024 17:45:00 +0400
+
 wb-configs (3.29.0) stable; urgency=medium
 
   * migrate udev rules installation to wb-prepare.d


### PR DESCRIPTION
Актуальные дебки ноды будут в нашей репе. Можно не бекпортить в стейбл, все равно nodejs в нашей репе свежее и будет браться от туда.