### PR TITLE
 Добавление пользователя в группу mosquitto

### DIFF
--- a/configs/etc/systemd/system/fcgiwrap.service.d/override.conf
+++ b/configs/etc/systemd/system/fcgiwrap.service.d/override.conf
@@ -1,4 +1,5 @@
 [Service]
 Environment="DAEMON_OPTS=-f -c 2"
+ExecStartPre=+/usr/sbin/usermod -aG mosquitto www-data
 ExecStart=
 ExecStart=/usr/sbin/fcgiwrap $DAEMON_OPTS

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.33.0) stable; urgency=medium
+
+  * Add user to mosquitto group (need for wb-cloud-agent vulnerability message in webui)
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Mon, 21 Oct 2024 16:00:00 +0300
+
 wb-configs (3.32.0) stable; urgency=medium
 
   * wb85x: ttyWBE0 -> ttyMOD1; ttyWBE1 -> ttyMOD2


### PR DESCRIPTION
Добавление пользователя в группу mosquitto (необходимо для сообщения о уязвимости wb-cloud-agent в веб-интерфейсе).