### PR TITLE
add eth0 & eth1 ip addrs to motd

### DIFF
--- a/configs/etc/update-motd.d/30-wirenboard-ipaddrs
+++ b/configs/etc/update-motd.d/30-wirenboard-ipaddrs
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for iface in eth0 eth1; do
+    ip="$(ifconfig "$iface" | awk '/inet/ {print $2}' | cut -f2 -d:)"
+    if [[ -n $ip ]]; then
+        echo "$iface ip: $ip"
+    fi
+done
+echo ""

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.36.0) stable; urgency=medium
+
+  * Add eth0 & eth1 ip addrs to motd
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 23 Jan 2025 18:12:01 +0300
+
 wb-configs (3.35.0) stable; urgency=medium
 
   * Add a 'crda' package for regional settings. Set a global regional setting for Wifi on KZ.


### PR DESCRIPTION
от инженеров прилетела хотелка: ip езернетов на логинскрине

![image](https://github.com/user-attachments/assets/c58804e8-1057-4b9a-8fb7-afd9dfe895ab)
у меня под рукой нормальных интернетов нет, поэтому картинка про lo и dbg0

стоит ли другие интерфейсы добавлять - хз; я б не добавлял пока