### PR TITLE
Установил системную локаль по-умолчанию в en_US.UTF8

### DIFF
--- a/configs/etc/default/locale
+++ b/configs/etc/default/locale
@@ -1,0 +1,2 @@
+LANG=en_US.UTF-8
+LC_ALL=en_US.UTF-8

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.37.0) stable; urgency=medium
+
+  * Set the system locale to en_US.UTF-8 by default to ensure correct rendering of pseudographics when connecting from SSH clients on Windows.
+
+ -- Anton <anton.tarasov@wirenboard.com>  Thu, 13 Feb 2025 11:08:46 +0300
+
 wb-configs (3.36.0) stable; urgency=medium
 
   * Add eth0 & eth1 ip addrs to motd


### PR DESCRIPTION
Прописал системуную локаль по-умолчанию в en_US.UTF8, чтобы с SSH-клиентов под windows корректно отображалась псевдографика.