### PR TITLE
Update authentication

### DIFF
--- a/configs/etc/nginx/sites-available/default.wb
+++ b/configs/etc/nginx/sites-available/default.wb
@@ -55,6 +55,7 @@ server {
         }
 
         set $required_user_type "user";
+        set $allow_if_no_users "true";
         auth_request /auth/check;
 
         fastcgi_param SCRIPT_FILENAME /usr/lib/cgi-bin/check.sh;
@@ -180,6 +181,7 @@ server {
 
 	location /mqtt {
 	    set $required_user_type "user";
+	    set $allow_if_no_users "true";
 	    auth_request /auth/check;
 
 	    proxy_pass http://127.0.0.1:18883;
@@ -194,16 +196,17 @@ server {
 		proxy_pass_request_body off;
 		proxy_set_header Content-Length "";
 		proxy_set_header Required-User-Type $required_user_type;
+		proxy_set_header Allow-If-No-Users $allow_if_no_users;
 		proxy_pass http://wb-homeui-back/auth/check;
 	}
 
 	location /auth/users {
-		auth_request off; # authentication is managed in the backend
+		set $required_user_type "admin";
+		set $allow_if_no_users "true";
 		proxy_pass http://wb-homeui-back/users;
 	}
 
 	location /login {
-		auth_request off;
 		limit_except POST {
 			deny all;
 		}
@@ -212,7 +215,6 @@ server {
 	}
 
 	location /logout {
-		auth_request off;
 		limit_except POST {
 			deny all;
 		}
@@ -220,7 +222,6 @@ server {
 	}
 
 	location /auth/who_am_i {
-		auth_request off;
 		limit_except GET {
 			deny all;
 		}
@@ -228,7 +229,6 @@ server {
 	}
 
 	location /device/info {
-		auth_request off;
 		limit_except GET {
 			deny all;
 		}


### PR DESCRIPTION
[Тут](https://github.com/wirenboard/wb-homeui-auth/pull/3) сделал консольную утилиту, которая ходит в unix-сокет и позволяет редактировать пользователей. Ей не нужна авторизация. Модифицировал конфиг так, чтобы авторизация была только для web-интерфейса.