### PR TITLE
Set default requirements for auth check

### DIFF
--- a/configs/etc/nginx/sites-available/default.wb
+++ b/configs/etc/nginx/sites-available/default.wb
@@ -38,6 +38,9 @@ server {
 	# Make site accessible from http://localhost/
 	server_name localhost;
 
+	set $required_user_type "admin";
+	set $allow_if_no_users "false";
+
 	location / {
 		index index.html;
 		try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Добавил установку значений переменных по умолчанию. Эти переменные используются при формировании заголовка запроса авторизации. Они задают требуемые права доступа, соответствие которым проверяется в запросе авторизации