### PR TITLE
Disable default route on dbg0

### DIFF
--- a/configs/etc/NetworkManager/dnsmasq-shared.d/no-default-route.conf
+++ b/configs/etc/NetworkManager/dnsmasq-shared.d/no-default-route.conf
@@ -1,0 +1,1 @@
+dhcp-option=dbg0,3

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.37.2) stable; urgency=medium
+
+  * Disable default route on dbg0
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Fri, 14 Mar 2025 10:46:47 +0300
+
 wb-configs (3.37.1) stable; urgency=medium
 
   * Change the locale setting in favor of executing the postinit-script


### PR DESCRIPTION
DHCP-сервер не будет передавать дефолтный маршрут по этому интерфейсу