### PR TITLE
Fix mosquitto acl and password file permissions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.38.1) stable; urgency=medium
+
+  * Fix mosquitto acl and password file permissions
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 24 Apr 2025 11:32:34 +0500
+
 wb-configs (3.38.0) stable; urgency=medium
 
   * Remove wb-mqtt-homeui related configs and scripts

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -266,6 +266,19 @@ mosquitto_fixes()
     fi
 
     /usr/lib/wb-configs/fix_mosquitto.sh
+
+    # Fix permissions for default ACL and password files
+    MOSQUITTO_ACL_CONF="/etc/mosquitto/acl/default.conf"
+    MOSQUITTO_PASSWD_CONF="/etc/mosquitto/passwd/default.conf"
+
+    chmod 0700 $MOSQUITTO_ACL_CONF
+    chmod 0700 $MOSQUITTO_PASSWD_CONF
+
+    chgrp mosquitto $MOSQUITTO_ACL_CONF
+    chgrp mosquitto $MOSQUITTO_PASSWD_CONF
+
+    chown mosquitto $MOSQUITTO_ACL_CONF
+    chown mosquitto $MOSQUITTO_PASSWD_CONF
 }
 
 mosquitto_fixes


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
```
Mar 03 15:03:36 wirenboard-AC4U5OVN mosquitto[1259575]: 1741014216: Warning: File /etc/mosquitto/acl/default.conf owner is not mosquitto. Future versions will refuse to load this file.To fix this, use `chown mosquitto /etc/mosquitto/acl/default.conf`.
Mar 03 15:03:36 wirenboard-AC4U5OVN mosquitto[1259575]: 1741014216: Warning: File /etc/mosquitto/acl/default.conf group is not mosquitto. Future versions will refuse to load this file.
Mar 03 15:03:36 wirenboard-AC4U5OVN mosquitto[1259575]: 1741014216: Warning: File /etc/mosquitto/acl/default.conf has world readable permissions. Future versions will refuse to load this file.
                                                        To fix this, use `chmod 0700 /etc/mosquitto/acl/default.conf`.
```
Москито ругается на права доступа у файликов

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


