### PR TITLE
fix udev rules triggering at firstboot

### DIFF
--- a/configs/etc/wb-prepare.d/01udev-rules
+++ b/configs/etc/wb-prepare.d/01udev-rules
@@ -40,4 +40,4 @@ else
     install_rules 99-wb-uart default
 fi
 
-udevadm trigger # apply new udev rules
+udevadm control --reload-rules; udevadm trigger # apply new udev rules

--- a/configs/etc/wb-prepare.d/01udev-rules
+++ b/configs/etc/wb-prepare.d/01udev-rules
@@ -40,4 +40,5 @@ else
     install_rules 99-wb-uart default
 fi
 
-udevadm control --reload-rules; udevadm trigger # apply new udev rules
+udevadm control --reload-rules
+udevadm trigger # apply new udev rules

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.38.2) stable; urgency=medium
+
+  * Fix udev rules triggering at firstboot
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Mon, 12 May 2025 15:45:01 +0300
+
 wb-configs (3.38.1) stable; urgency=medium
 
   * Fix mosquitto acl and password file permissions


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Проблема: udev-правила (expose uart pins) не работают при firstboot. Такое же - со всеми правилами, работающими в рантайме (что-то делаем через хвконф); правила при загрузке (например, переименование езернетов) работали и так.

Подебажил - udev все видит => гипотеза - надо дернуть перезагрузку правил. Гипотеза подтвердилась экспериментом: прошили -> firstboot -> убедились, что не работает -> reboot -> убедились, что работает.

Причина:
[не так давно](https://github.com/wirenboard/wb-configs/pull/175) мы перетащили udev-правила в рантайм => правила не перезагружаются после подмены

___________________________________
**Что поменялось для пользователей:**
ничего; пользователям уезжали вб, перезагружавшиеся уже минимум 1 раз => их и не затрагивало

___________________________________
**Как проверял/а:**
собрал FIT из тестинг-сета - подергал вокруг firstboot
