### PR TITLE
Fix mosquitto configs from wb-configs-early.service

### DIFF
--- a/configs/usr/lib/wb-configs/fix_mosquitto.sh
+++ b/configs/usr/lib/wb-configs/fix_mosquitto.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
 
+MOSQUITTO_CONF="/etc/mosquitto/mosquitto.conf"
+LISTENERS_CONF='/etc/mosquitto/conf.d/10listeners.conf'
+restart_required=0
+if grep -q "log_dest file /var/log/mosquitto/mosquitto.log" $MOSQUITTO_CONF; then
+    sed -i 's#log_dest file /var/log/mosquitto/mosquitto.log#log_dest syslog#' $MOSQUITTO_CONF
+    restart_required=1
+fi
+if grep -q "pid_file /var/run/mosquitto.pid" $MOSQUITTO_CONF; then
+    sed -i 's#pid_file /var/run/mosquitto.pid#pid_file /run/mosquitto/mosquitto.pid#' $MOSQUITTO_CONF
+    restart_required=1
+fi
+if ! grep -q -F "include_dir /usr/share/wb-configs/mosquitto" $MOSQUITTO_CONF; then
+    sed -i '\#include_dir /etc/mosquitto/conf.d#iinclude_dir /usr/share/wb-configs/mosquitto' $MOSQUITTO_CONF
+    restart_required=1
+fi
+if grep -q "persistence .*" $MOSQUITTO_CONF; then
+    sed -i 's@persistence .*@# persistence is disabled by default. enable in /etc/mosquitto/conf.d/000persistence.conf@' $MOSQUITTO_CONF
+    restart_required=1
+fi
+if grep -q "^listener 18883$" $LISTENERS_CONF; then
+	sed -i '/^listener 18883$/clistener 18883 lo' $LISTENERS_CONF
+	restart_required=1
+fi
+
 mosquitto_confs=("/etc/mosquitto/acl.conf"
                  "/etc/mosquitto/passwd.conf"
                  "/etc/mosquitto/conf.d/auth.conf"
@@ -29,3 +53,18 @@ for i in ${!mosquitto_confs[@]}; do
         fi
     fi
 done
+
+# Fix permissions for default ACL and password files
+MOSQUITTO_ACL_CONF="/etc/mosquitto/acl/default.conf"
+MOSQUITTO_PASSWD_CONF="/etc/mosquitto/passwd/default.conf"
+
+chmod 0700 $MOSQUITTO_ACL_CONF
+chmod 0700 $MOSQUITTO_PASSWD_CONF
+
+chgrp mosquitto $MOSQUITTO_ACL_CONF
+chgrp mosquitto $MOSQUITTO_PASSWD_CONF
+
+chown mosquitto $MOSQUITTO_ACL_CONF
+chown mosquitto $MOSQUITTO_PASSWD_CONF
+
+exit "$restart_required"

--- a/configs/usr/lib/wb-configs/fix_mosquitto.sh
+++ b/configs/usr/lib/wb-configs/fix_mosquitto.sh
@@ -11,7 +11,7 @@ if grep -q "pid_file /var/run/mosquitto.pid" $MOSQUITTO_CONF; then
     sed -i 's#pid_file /var/run/mosquitto.pid#pid_file /run/mosquitto/mosquitto.pid#' $MOSQUITTO_CONF
     restart_required=1
 fi
-if ! grep -q -F "include_dir /usr/share/wb-configs/mosquitto" $MOSQUITTO_CONF; then
+if ! grep -q -E "^[[:space:]]*include_dir /usr/share/wb-configs/mosquitto" $MOSQUITTO_CONF; then
     sed -i '\#include_dir /etc/mosquitto/conf.d#iinclude_dir /usr/share/wb-configs/mosquitto' $MOSQUITTO_CONF
     restart_required=1
 fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.38.3) stable; urgency=medium
+
+  * Fix mosquitto configs from wb-configs-early.service
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 22 May 2025 18:23:00 +0400
+
 wb-configs (3.38.2) stable; urgency=medium
 
   * Fix udev rules triggering at firstboot

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -234,51 +234,14 @@ add_mmc_mount_options
 
 mosquitto_fixes()
 {
-    MOSQUITTO_CONF="/etc/mosquitto/mosquitto.conf"
-    LISTENERS_CONF='/etc/mosquitto/conf.d/10listeners.conf'
-    local restart_required=0
-    if grep -q "log_dest file /var/log/mosquitto/mosquitto.log" $MOSQUITTO_CONF; then
-        sed -i 's#log_dest file /var/log/mosquitto/mosquitto.log#log_dest syslog#' $MOSQUITTO_CONF
-        restart_required=1
-    fi
-    if grep -q "pid_file /var/run/mosquitto.pid" $MOSQUITTO_CONF; then
-        sed -i 's#pid_file /var/run/mosquitto.pid#pid_file /run/mosquitto/mosquitto.pid#' $MOSQUITTO_CONF
-        restart_required=1
-    fi
-    if ! grep -q -F "include_dir /usr/share/wb-configs/mosquitto" $MOSQUITTO_CONF; then
-        sed -i '\#include_dir /etc/mosquitto/conf.d#iinclude_dir /usr/share/wb-configs/mosquitto' $MOSQUITTO_CONF
-        restart_required=1
-    fi
-    if grep -q "persistence .*" $MOSQUITTO_CONF; then
-        sed -i 's@persistence .*@# persistence is disabled by default. enable in /etc/mosquitto/conf.d/000persistence.conf@' $MOSQUITTO_CONF
-        restart_required=1
-    fi
-    if grep -q "^listener 18883$" $LISTENERS_CONF; then
-    	sed -i '/^listener 18883$/clistener 18883 lo' $LISTENERS_CONF
-    	restart_required=1
-    fi
-    if [ $restart_required -eq 1 ]; then
+    /usr/lib/wb-configs/fix_mosquitto.sh
+    if [ $? -eq 1 ]; then
         if [ "$(deb-systemd-invoke is-enabled mosquitto)" != "masked" ]; then
             deb-systemd-invoke restart mosquitto
         else
             echo "Mosquitto is masked, skipping restart"
         fi
     fi
-
-    /usr/lib/wb-configs/fix_mosquitto.sh
-
-    # Fix permissions for default ACL and password files
-    MOSQUITTO_ACL_CONF="/etc/mosquitto/acl/default.conf"
-    MOSQUITTO_PASSWD_CONF="/etc/mosquitto/passwd/default.conf"
-
-    chmod 0700 $MOSQUITTO_ACL_CONF
-    chmod 0700 $MOSQUITTO_PASSWD_CONF
-
-    chgrp mosquitto $MOSQUITTO_ACL_CONF
-    chgrp mosquitto $MOSQUITTO_PASSWD_CONF
-
-    chown mosquitto $MOSQUITTO_ACL_CONF
-    chown mosquitto $MOSQUITTO_PASSWD_CONF
 }
 
 mosquitto_fixes


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При обновлении фитом не применяются фиксы конфигов москиты. Затрагивает эти 6 фиксов:
* https://github.com/wirenboard/wb-configs/pull/89 (3.18.1, wb-2310)
* https://github.com/wirenboard/wb-configs/pull/122 (3.18.3, wb-2310)
* https://github.com/wirenboard/wb-configs/pull/148 (3.22.0, wb-2401)
* https://github.com/wirenboard/wb-configs/pull/165 (3.26.5, wb-2407)
* https://github.com/wirenboard/wb-configs/pull/176 (3.34.0, wb-2501)
* https://github.com/wirenboard/wb-configs/pull/204 (3.38.1, wb-2504)

Могло затрагивать пользователей, которые ни разу не обновлялись аптом, а только фитами.

Также wb-configs может при обновлении аптом обновится до mosquitto и тогда фиксы из postinst тоже не применятся. С этим же фиксом они в итоге применятся после ребута.
___________________________________
**Что поменялось для пользователей:**
Фиксы применяются при обновлении как аптом, так и фитом.

___________________________________
**Как проверял/а:**


