### PR TITLE
Don't override fw_env.config if uboot-env-offset/size exist

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.39.0) stable; urgency=medium
+
+  * Don't override fw_env.config if uboot-env-offset/size props exist in device tree
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 04 Jun 2025 17:35:00 +0400
+
 wb-configs (3.38.3) stable; urgency=medium
 
   * Fix mosquitto configs from wb-configs-early.service

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -16,7 +16,10 @@ elif of_machine_match "fsl,imx28" || of_machine_match "fsl,imx23"; then
 else
     FVER="default"
 fi
-cp "${UBOOT_DIR}/${UBOOT_FNAME}.${FVER}" "/etc/${UBOOT_FNAME}"
+
+if ! of_has_prop "wirenboard" "uboot-env-offset" || ! of_has_prop "wirenboard" "uboot-env-size"; then
+    cp "${UBOOT_DIR}/${UBOOT_FNAME}.${FVER}" "/etc/${UBOOT_FNAME}"
+fi
 
 ours=.wb
 theirs=.wb-orig


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Если uboot-env-offset/size прокинуты из убута в dt, то fw_env.config генерится динамически при firstboot (см https://github.com/wirenboard/wb-utils/pull/174) и не должен перетиратся при обновлении wb-configs.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
После apt install --reinstall wb-configs fw_env.config не перезаписан.

