### PR TITLE
Add /usr/share/wb-configs/mosquitto-post directory

### DIFF
--- a/configs/usr/lib/wb-configs/fix_mosquitto.sh
+++ b/configs/usr/lib/wb-configs/fix_mosquitto.sh
@@ -15,8 +15,12 @@ if ! grep -q -E "^[[:space:]]*include_dir /usr/share/wb-configs/mosquitto" $MOSQ
     sed -i '\#include_dir /etc/mosquitto/conf.d#iinclude_dir /usr/share/wb-configs/mosquitto' $MOSQUITTO_CONF
     restart_required=1
 fi
+if ! grep -q -E "^[[:space:]]*include_dir /usr/share/wb-configs/mosquitto-post" $MOSQUITTO_CONF; then
+    sed -i '/include_dir \/etc\/mosquitto\/conf.d/a include_dir /usr/share/wb-configs/mosquitto-post' $MOSQUITTO_CONF
+    restart_required=1
+fi
 if grep -q "persistence .*" $MOSQUITTO_CONF; then
-    sed -i 's@persistence .*@# persistence is disabled by default. enable in /etc/mosquitto/conf.d/000persistence.conf@' $MOSQUITTO_CONF
+    sed -i '/persistence .*/c# persistence is disabled by default. enable in /etc/mosquitto/conf.d/000persistence.conf' $MOSQUITTO_CONF
     restart_required=1
 fi
 if grep -q "^listener 18883$" $LISTENERS_CONF; then

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-configs (3.40.0) stable; urgency=medium
+
+  * Add /usr/share/wb-configs/mosquitto-post directory for adding configs after user defined
+  * Fix mosquitto.conf extra comments
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 04 Jul 2025 17:26:36 +0500
+
 wb-configs (3.39.1) stable; urgency=medium
 
   * Fix lintian, no functional changes

--- a/debian/wb-configs.dirs
+++ b/debian/wb-configs.dirs
@@ -1,0 +1,1 @@
+usr/share/wb-configs/mosquitto-post


### PR DESCRIPTION
 * Add /usr/share/wb-configs/mosquitto-post directory for adding configs after user defined
 * Fix mosquitto.conf extra comments

___________________________________
**Что происходит; кому и зачем нужно:**
Добавил каталог  /usr/share/wb-configs/mosquitto-post, который включается в конфиг после /etc/mosquitto/conf.d
Поправил баг с лишними комментариями

___________________________________
**Что поменялось для пользователей:**
Ничего

___________________________________
**Как проверял/а:**
Установил и посмотрел структуру каталогов и mosquitto.conf

