### PR TITLE
Remove bullseye-backports apt source

### DIFF
--- a/configs/etc/apt/preferences.d/50backports
+++ b/configs/etc/apt/preferences.d/50backports
@@ -1,3 +1,0 @@
-Package: libnm0 libmbim-*:any libqmi-*:any gir1.2-mbim-1.0 gir1.2-qmi-1.0
-Pin: release a=bullseye-backports
-Pin-Priority: 510

--- a/configs/etc/apt/sources.list.d/debian-upstream.list
+++ b/configs/etc/apt/sources.list.d/debian-upstream.list
@@ -1,4 +1,3 @@
 deb http://debian-mirror.wirenboard.com/debian bullseye main
 deb http://debian-mirror.wirenboard.com/debian bullseye-updates main
-deb http://debian-mirror.wirenboard.com/debian bullseye-backports main
 deb http://debian-mirror.wirenboard.com/debian-security bullseye-security main

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.41.0) stable; urgency=medium
+
+  * Remove bullseye-backports apt source
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 22 Jul 2025 17:35:00 +0400
+
 wb-configs (3.40.0) stable; urgency=medium
 
   * Add /usr/share/wb-configs/mosquitto-post directory for adding configs after user defined


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
bullseye-backports EOL, https://lists.debian.org/debian-backports-announce/2024/07/msg00000.html
```sh
# apt update
Hit:1 https://deb.wirenboard.com/wb7/bullseye testing InRelease
Hit:2 https://debian-mirror.wirenboard.com/debian bullseye InRelease
Get:3 https://debian-mirror.wirenboard.com/debian bullseye-updates InRelease [44.0 kB]
Ign:4 https://debian-mirror.wirenboard.com/debian bullseye-backports InRelease
Hit:5 https://debian-mirror.wirenboard.com/debian-security bullseye-security InRelease
Err:6 https://debian-mirror.wirenboard.com/debian bullseye-backports Release
  404  Not Found [IP: 52.19.109.145 443]
Reading package lists... Done
E: The repository 'http://debian-mirror.wirenboard.com/debian bullseye-backports Release' no longer has a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


