### PR TITLE
Remove bullseye-backports apt source (#211)

### DIFF
--- a/configs/etc/apt/preferences.d/50backports
+++ b/configs/etc/apt/preferences.d/50backports
@@ -1,3 +1,0 @@
-Package: libnm0 libmbim-*:any libqmi-*:any gir1.2-mbim-1.0 gir1.2-qmi-1.0
-Pin: release a=bullseye-backports
-Pin-Priority: 510

--- a/configs/etc/apt/sources.list.d/debian-upstream.list
+++ b/configs/etc/apt/sources.list.d/debian-upstream.list
@@ -1,4 +1,3 @@
 deb http://debian-mirror.wirenboard.com/debian bullseye main
 deb http://debian-mirror.wirenboard.com/debian bullseye-updates main
-deb http://debian-mirror.wirenboard.com/debian bullseye-backports main
 deb http://debian-mirror.wirenboard.com/debian-security bullseye-security main

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.38.3-wb100) stable; urgency=medium
+
+  * Remove bullseye-backports apt source
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 22 Jul 2025 17:35:00 +0400
+
 wb-configs (3.38.3) stable; urgency=medium
 
   * Fix mosquitto configs from wb-configs-early.service


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Backport https://github.com/wirenboard/wb-configs/pull/211

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


