### PR TITLE
add extended rootfs support

### DIFF
--- a/configs/etc/fstab.extended.wb
+++ b/configs/etc/fstab.extended.wb
@@ -1,0 +1,5 @@
+/dev/mmcblk0p2       /                    auto       discard,errors=remount-ro,noatime                                      0          1
+/dev/mmcblk0p3       none                 swap       noatime,discard,errors=remount-ro                                      0          0
+/dev/mmcblk1p1       /mnt/sdcard          auto       nofail,x-systemd.automount,x-systemd.device-timeout=2                  0          2
+/mnt/data/var/log    /var/log             none       bind                                                                   0          0
+configfs             /sys/kernel/config   configfs   defaults                                                               0          0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.42.0) stable; urgency=medium
+
+  * add extended rootfs support
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 23 Jul 2025 15:10:00 +0400
+
 wb-configs (3.41.0) stable; urgency=medium
 
   * Remove bullseye-backports apt source

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -227,7 +227,7 @@ add_mmc_mount_options(){
        if (options !~ TIME_OPTION_REGEX)
           options="noatime,"options;
     }
-    printf "%-20s %-20s %-10s %-70s %-10s %-10s\n", $1, $2, $3, options, $5, $6;
+    printf "%-20s %-20s %-10s %-70s %-10s %s\n", $1, $2, $3, options, $5, $6;
     }' /etc/fstab > /tmp/fstab_tmp
 
     mv /tmp/fstab_tmp /etc/fstab


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
https://github.com/wirenboard/wb-configs/pull/200, тут только сам fstab.extended, будет использоваться для замены fstab во время установки из фита.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


