### PR TITLE
Backup /etc/ssmtp configs to /mnt/data

### DIFF
--- a/configs/etc/wb-configs.d/01wb-configs
+++ b/configs/etc/wb-configs.d/01wb-configs
@@ -23,6 +23,7 @@ wb_move_watch /etc/network/interfaces
 
 wb_move /etc/resolv.conf
 wb_move /etc/ssh
+wb_move /etc/ssmtp
 wb_move /etc/dnsmasq.conf
 wb_move /etc/hostapd.conf
 wb_move /var/lib/wirenboard

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.41.1) stable; urgency=medium
+
+  * Backup /etc/ssmtp configs to /mnt/data
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 29 Jul 2025 17:35:00 +0400
+
 wb-configs (3.41.0) stable; urgency=medium
 
   * Remove bullseye-backports apt source


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Отправка email уведомлений настраивается по [инструкции](https://wirenboard.com/wiki/Notification_module#%D0%9F%D1%80%D0%B5%D0%B4%D0%B2%D0%B0%D1%80%D0%B8%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D0%B0%D1%8F_%D0%BD%D0%B0%D1%81%D1%82%D1%80%D0%BE%D0%B9%D0%BA%D0%B0_%D0%B4%D0%BB%D1%8F_%D0%BE%D1%82%D0%BF%D1%80%D0%B0%D0%B2%D0%BA%D0%B8_email) в `/etc/ssmtp/ssmtp.conf`. Но он не бекапится в `/mnt/data`, поэтому после обновления фитом отправка уведомлений не работает.

___________________________________
**Что поменялось для пользователей:**
 email уведомления отправлются после обновления фитом.

___________________________________
**Как проверял/а:**
установка, конфиги уехали в /mnt/data

