### PR TITLE
Features/soft 5777 disable bgscan

### DIFF
--- a/configs/etc/NetworkManager/dispatcher.d/50-no-bgscan
+++ b/configs/etc/NetworkManager/dispatcher.d/50-no-bgscan
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Disables bgscan for all wpa_supplicant profiles on the given interface.
+# Works only for STA (managed) mode. For iwd — simply does nothing.
+
+IFACE="$1"; STATE="$2"
+
+# Only interested in the moment when the interface is up:
+[ "$STATE" = "up" ] || exit 0
+
+# Must be STA (managed), otherwise exit (AP/monitor/p2p are not needed):
+TYPE="$(iw dev "$IFACE" info 2>/dev/null | awk '/type/ {print $2}')"
+[ "$TYPE" = "managed" ] || exit 0
+
+# wpa_cli must be available and a live supplicant must exist for this interface
+command -v wpa_cli >/dev/null 2>&1 || exit 0
+wpa_cli -i "$IFACE" ping >/dev/null 2>&1 || exit 0
+
+# Small retry: right after "up", CURRENT may not yet be marked:
+NET_ID=""
+tries=5
+while [ $tries -gt 0 ]; do
+    NET_ID="$(wpa_cli -i "$IFACE" list_networks 2>/dev/null \
+        | awk '$4=="[CURRENT]"{print $1; exit}')"
+    [ -n "$NET_ID" ] && break
+    sleep 0.2
+    tries=$((tries-1))
+done
+
+# If there is no current network — nothing to do:
+[ -n "$NET_ID" ] || exit 0
+
+# Disable bgscan (background scans) only for the current profile
+wpa_cli -i "$IFACE" set_network "$NET_ID" bgscan "" >/dev/null 2>&1
+
+exit 0
+

--- a/configs/usr/local/bin/nmtui
+++ b/configs/usr/local/bin/nmtui
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Wrapper for nmtui that forces Wi-Fi rescan before launch
+
+# Trigger rescan on all Wi-Fi interfaces
+for i in $(nmcli -t -f DEVICE,TYPE d | awk -F: '$2=="wifi" {print $1}'); do
+    nmcli dev wifi rescan ifname "$i"
+done
+
+# Small wait result scan
+sleep 0.5
+
+# Launch the real nmtui
+exec /usr/bin/nmtui "$@"
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.44.0) stable; urgency=medium
+
+  * Disable bgscan on STA interfaces
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Wed, 13 Aug 2025 09:37:23 +0300
+
 wb-configs (3.43.0) stable; urgency=medium
 
   * Add configs and service for start xinit and firefox in kiosk mode


### PR DESCRIPTION
NetworkManager инициирует сканирование сетей каждые 30 секунд - это вызывает задержки в работе сети (текущий канал "замирает" на 3-5 секунд) - что негативно сказывается на комфорте работы (например через SSH - сессия подвисает на это время).
С помощью dispatcher-скрипта и передачи параметра _bgscan_ в _wpa-supplicant_, отключил фоновое сканирование сети.

**Ручное сканирование сети:**
* `nmcli dev wifi list --rescan yes ifname wlan1`
* `iw dev wlan1 scan`
успешно отрабатывает.

**Конфигурация через веб-морду:**
При конфигурировании сети через веб-админку внутри вызывается сканирование сети, так что оно тоже отрабатывает успешно (в отличии от патча ядра, где запрещяется любое сканирование сети, когда WB подключен к точке доступа).

**Конфигурация через nmtui:**
Так как nmtui не запускает сканирования сети, а берет доступные сети из кэша BSS, то сделал обертку для него в /usr/local/bin/nmtui - которая выполняется до /usr/bin/nmtui и сперва запускает сканирование (которое обновляет кэш сетей BSS), а после сам nmtui
___________________________________
**Что происходит; кому и зачем нужно:**


Перестанут быть затыки в сети
___________________________________
**Что поменялось для пользователей:**

На контроллере
___________________________________
**Как проверял/а:**


