### PR TITLE
Features/soft 5567 ff crash bug

### DIFF
--- a/configs/etc/NetworkManager/dispatcher.d/50-no-bgscan
+++ b/configs/etc/NetworkManager/dispatcher.d/50-no-bgscan
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Disables bgscan for all wpa_supplicant profiles on the given interface.
+# Works only for STA (managed) mode. For iwd — simply does nothing.
+
+IFACE="$1"; STATE="$2"
+
+# Only interested in the moment when the interface is up:
+[ "$STATE" = "up" ] || exit 0
+
+# Must be STA (managed), otherwise exit (AP/monitor/p2p are not needed):
+TYPE="$(iw dev "$IFACE" info 2>/dev/null | awk '/type/ {print $2}')"
+[ "$TYPE" = "managed" ] || exit 0
+
+# wpa_cli must be available and a live supplicant must exist for this interface
+command -v wpa_cli >/dev/null 2>&1 || exit 0
+wpa_cli -i "$IFACE" ping >/dev/null 2>&1 || exit 0
+
+# Small retry: right after "up", CURRENT may not yet be marked:
+NET_ID=""
+tries=5
+while [ $tries -gt 0 ]; do
+    NET_ID="$(wpa_cli -i "$IFACE" list_networks 2>/dev/null \
+        | awk '$4=="[CURRENT]"{print $1; exit}')"
+    [ -n "$NET_ID" ] && break
+    sleep 0.2
+    tries=$((tries-1))
+done
+
+# If there is no current network — nothing to do:
+[ -n "$NET_ID" ] || exit 0
+
+# Disable bgscan (background scans) only for the current profile
+wpa_cli -i "$IFACE" set_network "$NET_ID" bgscan "" >/dev/null 2>&1
+
+exit 0
+

--- a/configs/etc/X11/xinit/xinitrc.wb
+++ b/configs/etc/X11/xinit/xinitrc.wb
@@ -1,9 +1,10 @@
 #!/bin/sh
+set -eu
 xset s off          # Disable screensaver
 xset -dpms          # Disable Display Power Management Signaling
 xset s noblank      # Disable blank screen
 
-# If mouse cursour hide -> run hidder app:
+# If the mouse cursor should be hidden -> run the hider app:
 mouse=$(jq -r '.mod4.options.mouse // "hide"' /etc/wb-hardware.conf 2>/dev/null)
 if [ -z "$mouse" ] || [ "$mouse" = "hide" ]; then
     # Hide cursor:
@@ -13,13 +14,13 @@ fi
 # Run WM
 matchbox-window-manager &
 
-# wait run WM
+# Wait for WM to start
 sleep 1
 
 # Read URL from /etc/wb-hardware.conf:
 url=$(jq -r '.mod4.options.url // "http://localhost"' /etc/wb-hardware.conf 2>/dev/null)
 
-# If zero URL -> set default URL:
+# If URL is empty -> set default URL:
 if [ -z "$url" ] || [ "$url" = "null" ]; then
     url="http://localhost"
 fi
@@ -32,13 +33,8 @@ if [ ! -d "$PROFILE_DIR" ]; then
     firefox --no-remote -CreateProfile "$PROFILE_NAME $PROFILE_DIR"
 
     # The Firefox --CreateProfile command may finish before the profile directory is actually created.
-    # So we need to explicitly check that the directory exists before continuing.
-
-    # TODO:
-    # Currently, a simple loop with sleep is used to wait for the directory to appear —
-    # it's a working but not very reliable solution.
-    # It should be replaced with a cleaner approach, such as using inotify or another method,
-    # to avoid unnecessary delays or potential issues.
+    # Explicitly wait for the directory to appear before continuing.
+    # TODO: Replace this simple sleep loop with a cleaner approach (e.g. inotify) to avoid unnecessary delays.
     for i in $(seq 1 10); do
         [ -d "$PROFILE_DIR" ] && break
         sleep 0.5
@@ -48,18 +44,48 @@ if [ ! -d "$PROFILE_DIR" ]; then
     cat <<- 'EOF' > "$PROFILE_DIR/user.js"
 	user_pref("browser.sessionstore.resume_from_crash", false);
 	user_pref("browser.shell.checkDefaultBrowser", false);
-	user_pref("toolkit.startup.max_resumed_crashes", 0);
+	user_pref("toolkit.startup.max_resumed_crashes", -1);
+	user_pref("browser.crashReports.unsubmittedCheck.enabled", false);
+	user_pref("datareporting.policy.dataSubmissionEnabled", false);
+	user_pref("signon.rememberSignons", false);
+	user_pref("signon.autofillForms", false);
+	user_pref("signon.autologin.proxy", false);
 EOF
 fi
 
-# Remove session files:
-rm -f "$PROFILE_DIR/sessionstore.js" \
-      "$PROFILE_DIR/sessionstore.bak"
+# Strict but safe (for logins) cleanup of crash/start markers:
 
-if [ -d "$PROFILE_DIR/sessionstore-backups" ]; then
-    rm -f "$PROFILE_DIR/sessionstore-backups/"*.jsonlz4
-fi
+# 1) Main startup watchdog:
+rm -f "$PROFILE_DIR/.startup-incomplete" 2>/dev/null || true
+
+# 2) Session/restore files (duplicated for idempotency):
+rm -f "$PROFILE_DIR/sessionCheckpoints.json" 2>/dev/null || true
+rm -f "$PROFILE_DIR/sessionstore.jsonlz4" "$PROFILE_DIR/sessionstore.js" "$PROFILE_DIR/sessionstore.bak" 2>/dev/null || true
+rm -rf "$PROFILE_DIR/sessionstore-backups" 2>/dev/null || true
+
+# 3) Crash reporter/minidumps:
+rm -rf "$PROFILE_DIR/crashes" "$PROFILE_DIR/minidumps" 2>/dev/null || true
+
+# 4) Telemetry markers that may trigger “previous crash” reminders:
+rm -f "$PROFILE_DIR/datareporting/aborted-session-ping" 2>/dev/null || true
+rm -rf "$PROFILE_DIR/datareporting/glean/pending_pings" 2>/dev/null || true
+
+# 5) Global directories outside the profile (shared by all profiles for root user):
+rm -rf "/root/.mozilla/firefox/Crash Reports" 2>/dev/null || true
+rm -rf "/root/.mozilla/firefox/Pending Pings" 2>/dev/null || true
+rm -rf "/root/.mozilla/Crash Reports" 2>/dev/null || true
+rm -rf "/root/.mozilla/Pending Pings" 2>/dev/null || true
+
+# 6) Remove leftover session lock markers:
+rm -f "$PROFILE_DIR/lock" "$PROFILE_DIR/.parentlock" 2>/dev/null || true
+
+# 7) Clean up shutdown time/state telemetry markers:
+rm -f "$PROFILE_DIR/Telemetry.ShutdownTime.txt" "$PROFILE_DIR/times.json" 2>/dev/null || true
+rm -f "$PROFILE_DIR/datareporting/session-state.json" "$PROFILE_DIR/datareporting/state.json" 2>/dev/null || true
 
 # Run FireFox in kiosk mode:
-firefox --no-remote --kiosk --profile "$PROFILE_DIR" "$url"
+export MOZ_CRASHREPORTER_DISABLE=1
+export MOZ_DISABLE_SAFE_MODE_KEY=1
+
+exec firefox --no-remote --kiosk --profile "$PROFILE_DIR" "$url"
 

--- a/configs/usr/local/bin/nmtui
+++ b/configs/usr/local/bin/nmtui
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Wrapper for nmtui that forces Wi-Fi rescan before launch
+
+# Trigger rescan on all Wi-Fi interfaces
+for i in $(nmcli -t -f DEVICE,TYPE d | awk -F: '$2=="wifi" {print $1}'); do
+    nmcli dev wifi rescan ifname "$i"
+done
+
+# Small wait result scan
+sleep 0.5
+
+# Launch the real nmtui
+exec /usr/bin/nmtui "$@"
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.45.0) stable; urgency=medium
+
+  * Cleanup crash/session markers to prevent recovery prompts for FireFox
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Wed, 13 Aug 2025 20:21:12 +0300
+
 wb-configs (3.44.0) stable; urgency=medium
 
   * Disable bgscan on STA interfaces

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.44.0) stable; urgency=medium
+
+  * Disable bgscan on STA interfaces
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Wed, 13 Aug 2025 09:37:23 +0300
+
 wb-configs (3.43.0) stable; urgency=medium
 
   * Add configs and service for start xinit and firefox in kiosk mode


### PR DESCRIPTION
**Что происходит; кому и зачем нужно:**
FireFox оставлял следы того, что он плохо завершился.
Это вызывало окно с уведомлением пользователю об неуспешном последнем запуске (не предложение восстановить сессию, а именно уведомление).
Что вызывало перезапуск графической сессии.

___________________________________
**Что поменялось для пользователей:**
FF запускается как с нуля, но при этом сохраняются данные о залогиненности (куки, пароли и тп).

___________________________________
**Как проверял/а:**
На WB8.5 с HDMI всячески прибивая xinit/FF.