### PR TITLE
 xinitrc.wb: cleanup crash/session markers to prevent recovery prompt…

### DIFF
--- a/configs/etc/X11/xinit/xinitrc.wb
+++ b/configs/etc/X11/xinit/xinitrc.wb
@@ -1,9 +1,10 @@
 #!/bin/sh
+set -eu
 xset s off          # Disable screensaver
 xset -dpms          # Disable Display Power Management Signaling
 xset s noblank      # Disable blank screen
 
-# If mouse cursour hide -> run hidder app:
+# If the mouse cursor should be hidden -> run the hider app:
 mouse=$(jq -r '.mod4.options.mouse // "hide"' /etc/wb-hardware.conf 2>/dev/null)
 if [ -z "$mouse" ] || [ "$mouse" = "hide" ]; then
     # Hide cursor:
@@ -13,13 +14,13 @@ fi
 # Run WM
 matchbox-window-manager &
 
-# wait run WM
+# Wait for WM to start
 sleep 1
 
 # Read URL from /etc/wb-hardware.conf:
 url=$(jq -r '.mod4.options.url // "http://localhost"' /etc/wb-hardware.conf 2>/dev/null)
 
-# If zero URL -> set default URL:
+# If URL is empty -> set default URL:
 if [ -z "$url" ] || [ "$url" = "null" ]; then
     url="http://localhost"
 fi
@@ -32,13 +33,8 @@ if [ ! -d "$PROFILE_DIR" ]; then
     firefox --no-remote -CreateProfile "$PROFILE_NAME $PROFILE_DIR"
 
     # The Firefox --CreateProfile command may finish before the profile directory is actually created.
-    # So we need to explicitly check that the directory exists before continuing.
-
-    # TODO:
-    # Currently, a simple loop with sleep is used to wait for the directory to appear —
-    # it's a working but not very reliable solution.
-    # It should be replaced with a cleaner approach, such as using inotify or another method,
-    # to avoid unnecessary delays or potential issues.
+    # Explicitly wait for the directory to appear before continuing.
+    # TODO: Replace this simple sleep loop with a cleaner approach (e.g. inotify) to avoid unnecessary delays.
     for i in $(seq 1 10); do
         [ -d "$PROFILE_DIR" ] && break
         sleep 0.5
@@ -48,18 +44,48 @@ if [ ! -d "$PROFILE_DIR" ]; then
     cat <<- 'EOF' > "$PROFILE_DIR/user.js"
 	user_pref("browser.sessionstore.resume_from_crash", false);
 	user_pref("browser.shell.checkDefaultBrowser", false);
-	user_pref("toolkit.startup.max_resumed_crashes", 0);
+	user_pref("toolkit.startup.max_resumed_crashes", -1);
+	user_pref("browser.crashReports.unsubmittedCheck.enabled", false);
+	user_pref("datareporting.policy.dataSubmissionEnabled", false);
+	user_pref("signon.rememberSignons", false);
+	user_pref("signon.autofillForms", false);
+	user_pref("signon.autologin.proxy", false);
 EOF
 fi
 
-# Remove session files:
-rm -f "$PROFILE_DIR/sessionstore.js" \
-      "$PROFILE_DIR/sessionstore.bak"
+# Strict but safe (for logins) cleanup of crash/start markers:
 
-if [ -d "$PROFILE_DIR/sessionstore-backups" ]; then
-    rm -f "$PROFILE_DIR/sessionstore-backups/"*.jsonlz4
-fi
+# 1) Main startup watchdog:
+rm -f "$PROFILE_DIR/.startup-incomplete" 2>/dev/null || true
+
+# 2) Session/restore files (duplicated for idempotency):
+rm -f "$PROFILE_DIR/sessionCheckpoints.json" 2>/dev/null || true
+rm -f "$PROFILE_DIR/sessionstore.jsonlz4" "$PROFILE_DIR/sessionstore.js" "$PROFILE_DIR/sessionstore.bak" 2>/dev/null || true
+rm -rf "$PROFILE_DIR/sessionstore-backups" 2>/dev/null || true
+
+# 3) Crash reporter/minidumps:
+rm -rf "$PROFILE_DIR/crashes" "$PROFILE_DIR/minidumps" 2>/dev/null || true
+
+# 4) Telemetry markers that may trigger “previous crash” reminders:
+rm -f "$PROFILE_DIR/datareporting/aborted-session-ping" 2>/dev/null || true
+rm -rf "$PROFILE_DIR/datareporting/glean/pending_pings" 2>/dev/null || true
+
+# 5) Global directories outside the profile (shared by all profiles for root user):
+rm -rf "/root/.mozilla/firefox/Crash Reports" 2>/dev/null || true
+rm -rf "/root/.mozilla/firefox/Pending Pings" 2>/dev/null || true
+rm -rf "/root/.mozilla/Crash Reports" 2>/dev/null || true
+rm -rf "/root/.mozilla/Pending Pings" 2>/dev/null || true
+
+# 6) Remove leftover session lock markers:
+rm -f "$PROFILE_DIR/lock" "$PROFILE_DIR/.parentlock" 2>/dev/null || true
+
+# 7) Clean up shutdown time/state telemetry markers:
+rm -f "$PROFILE_DIR/Telemetry.ShutdownTime.txt" "$PROFILE_DIR/times.json" 2>/dev/null || true
+rm -f "$PROFILE_DIR/datareporting/session-state.json" "$PROFILE_DIR/datareporting/state.json" 2>/dev/null || true
 
 # Run FireFox in kiosk mode:
-firefox --no-remote --kiosk --profile "$PROFILE_DIR" "$url"
+export MOZ_CRASHREPORTER_DISABLE=1
+export MOZ_DISABLE_SAFE_MODE_KEY=1
+
+exec firefox --no-remote --kiosk --profile "$PROFILE_DIR" "$url"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.45.0) stable; urgency=medium
+
+  * xinitrc.wb: cleanup crash/session markers to prevent recovery prompts in kiosk mode
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Thu, 14 Aug 2025 11:09:48 +0300
+
 wb-configs (3.44.1) stable; urgency=medium
 
   * Move nmtui wrapper to /usr/bin and add alias


### PR DESCRIPTION
**Что происходит; кому и зачем нужно:**

FireFox оставлял следы того, что он плохо завершился.
Это вызывало окно с уведомлением пользователю об неуспешном последнем запуске (не предложение восстановить сессию, а именно уведомление).
Что вызывало перезапуск графической сессии.

---

**Что поменялось для пользователей:**

FF запускается как с нуля, но при этом сохраняются данные о залогиненности (куки, пароли и тп).

---

**Как проверял/а:**

На WB8.5 с HDMI всячески прибивая xinit/FF.
