### PR TITLE
Feature/int 503 nginx service restart on error

### DIFF
--- a/configs/etc/systemd/system/nginx.service.d/restart.conf
+++ b/configs/etc/systemd/system/nginx.service.d/restart.conf
@@ -1,0 +1,5 @@
+[Service]
+Restart=on-failure
+RestartSec=5s
+RestartMaxDelaySec=120s
+RestartSteps=5

--- a/configs/etc/systemd/system/nginx.service.d/restart.conf
+++ b/configs/etc/systemd/system/nginx.service.d/restart.conf
@@ -2,5 +2,4 @@
 Restart=on-failure
 RestartSec=5
 StartLimitIntervalSec=120
-StartLimitBurst=0
 TimeoutStartSec=30

--- a/configs/etc/systemd/system/nginx.service.d/restart.conf
+++ b/configs/etc/systemd/system/nginx.service.d/restart.conf
@@ -1,5 +1,5 @@
 [Service]
 Restart=on-failure
-RestartSec=5s
-RestartMaxDelaySec=120s
+RestartSec=5
+RestartMaxDelaySec=120
 RestartSteps=5

--- a/configs/etc/systemd/system/nginx.service.d/restart.conf
+++ b/configs/etc/systemd/system/nginx.service.d/restart.conf
@@ -1,5 +1,6 @@
 [Service]
 Restart=on-failure
 RestartSec=5
-RestartMaxDelaySec=120
-RestartSteps=5
+StartLimitIntervalSec=120
+StartLimitBurst=0
+TimeoutStartSec=30

--- a/configs/etc/systemd/system/nginx.service.d/restart.conf
+++ b/configs/etc/systemd/system/nginx.service.d/restart.conf
@@ -1,5 +1,5 @@
 [Service]
 Restart=on-failure
 RestartSec=5
-StartLimitIntervalSec=120
+StartLimitInterval=120
 TimeoutStartSec=30

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.46.0) stable; urgency=medium
+
+  * Add nginx service restart on failure
+
+ -- Mikhail Burchu <mikhail.burchu@wirenboard.com>  Tue, 2 Sep 2025 12:00:00 +0300
+
 wb-configs (3.45.0) stable; urgency=medium
 
   * xinitrc.wb: cleanup crash/session markers to prevent recovery prompts in kiosk mode


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
У нас настройки nginx таковы, что при фейле он даже не пытается рестартонуть. И при сбое, например, при недоступности крипточипа, падает вебка даже если сбой кратковременный. Потом соответственно nginx не рестартует и контроллер висит без вебки пока руками не перезагрузить nginx.

___________________________________
**Что поменялось для пользователей:**
Теперь при подобном сбое nginx будет пытаться запуститься, и если сбой кратковременный, то указанная проблема не возникает.

___________________________________
**Как проверял/а:**
Проверял на контроллерах 6, 7, 8.

