### PR TITLE
Features/hdmi 4 k

### DIFF
--- a/configs/lib/systemd/system/xinit.service
+++ b/configs/lib/systemd/system/xinit.service
@@ -2,7 +2,6 @@
 Description=Looped xinit launcher
 After=multi-user.target
 ConditionPathExists=/usr/bin/xinit
-ConditionPathExists=/dev/fb0
 
 [Service]
 ExecStart=/usr/bin/xinit /etc/X11/xinit/xinitrc.wb

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.47.0) stable; urgency=medium
+
+  * Remove the /dev/fb0 condition for xinit.service: Xorg can launch without fbdev now, and on 4K panels fb0 may not appear. Without this check, xinit actually starts even when fbdev fails.
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Wed, 24 Sep 2025 18:37:07 +0300
+
 wb-configs (3.46.0) stable; urgency=medium
 
   * Add nginx service restart on failure


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Удалил ConditionPathExists=/dev/fb0 для сервиса xinit
Xorg стартует и без fbdev. На 4K-панелях fb0 может не появиться, из-за чего xinit вовсе не запускался, хотя DPI/режимы для запуска Xorg-а подстраиваем отдельно. Сервис теперь не зависит от наличия fb0.

___________________________________
**Что поменялось для пользователей:**
Более стабильная работа Xorg

___________________________________
**Как проверял/а:**
На контроллере Wb8
