### PR TITLE
fill fw_env.config at system early boot (if uboot supports it)

### DIFF
--- a/configs/usr/bin/wb-configs-early
+++ b/configs/usr/bin/wb-configs-early
@@ -186,8 +186,34 @@ set_fwupdate_permissions()
     fi
 }
 
+maybe_fix_uboot_dynamic_env()
+{
+    local actual_env_offset=$(cat /proc/device-tree/wirenboard/uboot-env-offset 2>/dev/null) || true
+    local actual_env_size=$(cat /proc/device-tree/wirenboard/uboot-env-size 2>/dev/null) || true
+    local uboot_config="/etc/fw_env.config"
+    local target_device=$1
+
+    if [[ ! -z $actual_env_offset ]] && [[ ! -z $actual_env_size ]]; then
+        echo "Found actual uboot env offset: $actual_env_offset & size: $actual_env_size; Filling $uboot_config"
+        cat > $uboot_config << EOF
+# Configuration file for fw_(printenv/setenv) utility.
+# Up to two entries are valid, in this case the redundant
+# environment sector is assumed present.
+#
+# XXX this configuration might miss a fifth parameter for the "Number of
+# sectors"
+
+# MTD device name   Device offset   Env. size   Flash sector size
+$target_device        0x$actual_env_offset         0x$actual_env_size
+EOF
+    else
+        echo "Using $uboot_config from rootfs"
+    fi
+}
+
 case "$1" in
   start)
+    maybe_fix_uboot_dynamic_env /dev/mmcblk0
     do_start
     set_fwupdate_permissions
     ;;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.50.1) stable; urgency=medium
+
+  * Fill fw_env.config at system early boot (if uboot supports it)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 02 Apr 2026 16:45:21 +0300
+
 wb-configs (3.50.0) stable; urgency=medium
 
   * Update default fw_env.config for WB7


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
наполняем fw_env.config актуальной информацией как можно раньше при старте wb

___________________________________
**Что поменялось для пользователей:**
ничего; еще не доехало до пользователей

___________________________________
**Как проверял/а:**
собрал fit из тестинг-сета; погонял на wb7

