### PR TITLE
Fix fix_nm_ap_ssid.sh

### DIFF
--- a/configs/usr/lib/wb-configs/fix_nm_ap_ssid.sh
+++ b/configs/usr/lib/wb-configs/fix_nm_ap_ssid.sh
@@ -4,7 +4,7 @@ wb_ap_ssid_prefix="${WB_AP_SSID_PREFIX:-WirenBoard}"
 
 # find Wi-Fi module
 wifi_module="RTL8723BU"
-if [ -z $(lsusb -d'0bda:b720') ]; then
+if [ -z "$(lsusb -d'0bda:b720')" ]; then
     wifi_module="RTL8733BU"
 fi
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.51.1) stable; urgency=medium
+
+  * Fix fix_nm_ap_ssid.sh
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 11 Jun 2026 10:20:00 +0400
+
 wb-configs (3.51.0) stable; urgency=medium
 
   * Port for Debian 13


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
```sh
$ /usr/lib/wb-configs/fix_nm_ap_ssid.sh
/usr/lib/wb-configs/fix_nm_ap_ssid.sh: line 7: [: too many arguments
$ lsusb -d'0bda:b720'
Bus 002 Device 002: ID 0bda:b720 Realtek Semiconductor Corp. RTL8723BU 802.11b/g/n WLAN Adapter
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


