### PR TITLE
Remove debian-upstream.list

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (3.51.2) stable; urgency=medium
+
+  * Remove debian-upstream.list
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 19 Jun 2026 08:20:00 +0400
+
 wb-configs (3.51.1) stable; urgency=medium
 
   * Fix fix_nm_ap_ssid.sh

--- a/debian/wb-configs.maintscript
+++ b/debian/wb-configs.maintscript
@@ -3,6 +3,7 @@ rm_conffile /etc/init.d/wb-configs 1.76~
 rm_conffile /etc/apt/sources.list.d/contactless.list 1.76~
 rm_conffile /etc/apt/sources.list.d/wheezy-backports.list 1.76~
 rm_conffile /etc/apt/sources.list.d/nodesource.list 3.30.1~
+rm_conffile /etc/apt/sources.list.d/debian-upstream.list 3.51.2~
 rm_conffile /etc/apt/preferences 1.78~
 rm_conffile /etc/preferences 1.78~
 rm_conffile /etc/mosquitto/conf.d/auth.conf 3.0.0~


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
сорс переименован в debian-upstream.sources, старый debian-upstream.list можно удалить

___________________________________
**Что поменялось для пользователей:**
нет плашки с предложением удалить вручную

___________________________________
**Как проверял/а:**
локально

